### PR TITLE
Fixed broken Analytics

### DIFF
--- a/src/main/java/org/cyclops/cyclopscore/tracking/Analytics.java
+++ b/src/main/java/org/cyclops/cyclopscore/tracking/Analytics.java
@@ -71,7 +71,7 @@ public class Analytics {
                             }
                         }
                     }
-                }).run();
+                }).start();
             }
         }
     }


### PR DESCRIPTION
Your Analytics causes servers to hang forever at startup if the url is blocked or unavailable, since you manually run the thread's run methods instead of starting a new thread.
