### PR TITLE
Fix FluidHandlerItemCapacity.Storage type

### DIFF
--- a/src/main/java/org/cyclops/cyclopscore/capability/fluid/FluidHandlerItemCapacity.java
+++ b/src/main/java/org/cyclops/cyclopscore/capability/fluid/FluidHandlerItemCapacity.java
@@ -65,6 +65,13 @@ public class FluidHandlerItemCapacity extends FluidHandlerItemStack implements I
     }
 
     @Override
+    public void setFluid(FluidStack fluid) {
+        // We need this override because it's protected in FluidHandlerItemStack,
+        // but IFluidHandlerItemCapacity needs it to be public.
+        super.setFluid(fluid);
+    }
+
+    @Override
     public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
         return capability == FluidHandlerItemCapacityConfig.CAPABILITY || super.hasCapability(capability, facing);
     }
@@ -75,10 +82,10 @@ public class FluidHandlerItemCapacity extends FluidHandlerItemStack implements I
         return capability == FluidHandlerItemCapacityConfig.CAPABILITY ? (T) this : super.getCapability(capability, facing);
     }
 
-    public static class Storage implements Capability.IStorage<FluidHandlerItemCapacity> {
+    public static class Storage implements Capability.IStorage<IFluidHandlerItemCapacity> {
 
         @Override
-        public NBTBase writeNBT(Capability<FluidHandlerItemCapacity> capability, FluidHandlerItemCapacity instance, EnumFacing side) {
+        public NBTBase writeNBT(Capability<IFluidHandlerItemCapacity> capability, IFluidHandlerItemCapacity instance, EnumFacing side) {
             NBTTagCompound nbt = new NBTTagCompound();
             FluidStack fluid = instance.getFluid();
             if (fluid != null) {
@@ -91,7 +98,7 @@ public class FluidHandlerItemCapacity extends FluidHandlerItemStack implements I
         }
 
         @Override
-        public void readNBT(Capability<FluidHandlerItemCapacity> capability, FluidHandlerItemCapacity instance, EnumFacing side, NBTBase nbt) {
+        public void readNBT(Capability<IFluidHandlerItemCapacity> capability, IFluidHandlerItemCapacity instance, EnumFacing side, NBTBase nbt) {
             NBTTagCompound tags = (NBTTagCompound) nbt;
             if (tags.hasKey("capacity", MinecraftHelpers.NBTTag_Types.NBTTagInt.ordinal())) {
                 instance.setCapacity(tags.getInteger("capacity"));

--- a/src/main/java/org/cyclops/cyclopscore/capability/fluid/FluidHandlerItemCapacity.java
+++ b/src/main/java/org/cyclops/cyclopscore/capability/fluid/FluidHandlerItemCapacity.java
@@ -65,13 +65,6 @@ public class FluidHandlerItemCapacity extends FluidHandlerItemStack implements I
     }
 
     @Override
-    public void setFluid(FluidStack fluid) {
-        // We need this override because it's protected in FluidHandlerItemStack,
-        // but IFluidHandlerItemCapacity needs it to be public.
-        super.setFluid(fluid);
-    }
-
-    @Override
     public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
         return capability == FluidHandlerItemCapacityConfig.CAPABILITY || super.hasCapability(capability, facing);
     }
@@ -87,7 +80,7 @@ public class FluidHandlerItemCapacity extends FluidHandlerItemStack implements I
         @Override
         public NBTBase writeNBT(Capability<IFluidHandlerItemCapacity> capability, IFluidHandlerItemCapacity instance, EnumFacing side) {
             NBTTagCompound nbt = new NBTTagCompound();
-            FluidStack fluid = instance.getFluid();
+            FluidStack fluid = ((FluidHandlerItemCapacity)instance).getFluid();
             if (fluid != null) {
                 fluid.writeToNBT(nbt);
             } else {
@@ -104,7 +97,7 @@ public class FluidHandlerItemCapacity extends FluidHandlerItemStack implements I
                 instance.setCapacity(tags.getInteger("capacity"));
             }
             FluidStack fluid = FluidStack.loadFluidStackFromNBT(tags);
-            instance.setFluid(fluid);
+            ((FluidHandlerItemCapacity)instance).setFluid(fluid);
         }
     }
 }

--- a/src/main/java/org/cyclops/cyclopscore/capability/fluid/FluidHandlerItemCapacityConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/capability/fluid/FluidHandlerItemCapacityConfig.java
@@ -10,7 +10,7 @@ import org.cyclops.cyclopscore.config.extendedconfig.CapabilityConfig;
  * @author rubensworks
  *
  */
-public class FluidHandlerItemCapacityConfig extends CapabilityConfig {
+public class FluidHandlerItemCapacityConfig extends CapabilityConfig<IFluidHandlerItemCapacity> {
 
     /**
      * The unique instance.

--- a/src/main/java/org/cyclops/cyclopscore/capability/fluid/IFluidHandlerItemCapacity.java
+++ b/src/main/java/org/cyclops/cyclopscore/capability/fluid/IFluidHandlerItemCapacity.java
@@ -1,5 +1,8 @@
 package org.cyclops.cyclopscore.capability.fluid;
 
+import javax.annotation.Nullable;
+
+import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
 /**
@@ -10,5 +13,7 @@ public interface IFluidHandlerItemCapacity extends IFluidHandlerItem {
 
     public void setCapacity(int capacity);
     public int getCapacity();
+    @Nullable public FluidStack getFluid();
+    public void setFluid(FluidStack fluid);
 
 }

--- a/src/main/java/org/cyclops/cyclopscore/capability/fluid/IFluidHandlerItemCapacity.java
+++ b/src/main/java/org/cyclops/cyclopscore/capability/fluid/IFluidHandlerItemCapacity.java
@@ -1,8 +1,5 @@
 package org.cyclops.cyclopscore.capability.fluid;
 
-import javax.annotation.Nullable;
-
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 
 /**
@@ -13,7 +10,5 @@ public interface IFluidHandlerItemCapacity extends IFluidHandlerItem {
 
     public void setCapacity(int capacity);
     public int getCapacity();
-    @Nullable public FluidStack getFluid();
-    public void setFluid(FluidStack fluid);
 
 }


### PR DESCRIPTION
In IStorage<T>, the T is supposed to be the interface, not the implementation. https://github.com/MinecraftForge/MinecraftForge/blob/1.12.x/src/main/java/net/minecraftforge/common/capabilities/CapabilityManager.java#L53 shows the signature as `public <T> void register(Class<T> type, Capability.IStorage<T> storage, final Class<? extends T> implementation)`.