### PR TITLE
Add an additional type parameter to ExtendedConfig

### DIFF
--- a/src/main/java/org/cyclops/cyclopscore/client/render/model/RenderModel.java
+++ b/src/main/java/org/cyclops/cyclopscore/client/render/model/RenderModel.java
@@ -27,13 +27,13 @@ public abstract class RenderModel<T extends Entity, M extends ModelBase> extends
      * @param renderManager The render manager
      * @param config The config.
      */
-    public RenderModel(RenderManager renderManager, ExtendedConfig<?> config) {
+    public RenderModel(RenderManager renderManager, ExtendedConfig<?, ?> config) {
         super(renderManager);
         texture = createResourceLocation(config);
         model = constructModel();
     }
 
-    protected ResourceLocation createResourceLocation(ExtendedConfig<?> config) {
+    protected ResourceLocation createResourceLocation(ExtendedConfig<?, ?> config) {
         return new ResourceLocation(config.getMod().getModId(), config.getMod().getReferenceValue(ModBase.REFKEY_TEXTURE_PATH_MODELS) + config.getNamedId() + ".png");
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/ConfigHandler.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/ConfigHandler.java
@@ -36,12 +36,12 @@ import java.util.concurrent.Callable;
 @SuppressWarnings("rawtypes")
 @EqualsAndHashCode(callSuper=false)
 @Data
-public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
+public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?, ?>> {
 
     private final ModBase mod;
     private Configuration config;
-    private final LinkedHashSet<ExtendedConfig<?>> processedConfigs = new LinkedHashSet<ExtendedConfig<?>>();
-    private final Map<String, ExtendedConfig<?>> configDictionary = Maps.newHashMap();
+    private final LinkedHashSet<ExtendedConfig<?, ?>> processedConfigs = new LinkedHashSet<ExtendedConfig<?, ?>>();
+    private final Map<String, ExtendedConfig<?, ?>> configDictionary = Maps.newHashMap();
     private final Set<String> categories = Sets.newHashSet();
     private final Map<String, ConfigProperty> commandableProperties = Maps.newHashMap();
     private final Multimap<Class<?>, Pair<IForgeRegistryEntry<?>, Callable<?>>> registryEntriesHolder = Multimaps.newListMultimap(Maps.<Class<?>, Collection<Pair<IForgeRegistryEntry<?>, Callable<?>>>>newIdentityHashMap(), new Supplier<List<Pair<IForgeRegistryEntry<?>, Callable<?>>>>() {
@@ -59,12 +59,12 @@ public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
     }
     
     @Override
-    public boolean add(ExtendedConfig<?> e) {
+    public boolean add(ExtendedConfig<?, ?> e) {
     	addToConfigDictionary(e);
     	return super.add(e);
     }
 
-    public void addToConfigDictionary(ExtendedConfig<?> e) {
+    public void addToConfigDictionary(ExtendedConfig<?, ?> e) {
         configDictionary.put(e.getNamedId(), e);
     }
     
@@ -101,7 +101,7 @@ public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
      */
     @SuppressWarnings("unchecked")
     public void loadConfig() {
-        for(ExtendedConfig<?> eConfig : this) {
+        for(ExtendedConfig<?, ?> eConfig : this) {
             try {
                 addCategory(eConfig.getHolderType().getCategory());
                 if (!eConfig.isHardDisabled()) {
@@ -146,7 +146,7 @@ public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
      */
     @SuppressWarnings("unchecked")
     public void polishConfigs() {
-        for(ExtendedConfig<?> eConfig : processedConfigs) {
+        for(ExtendedConfig<?, ?> eConfig : processedConfigs) {
             ConfigurableType type = eConfig.getHolderType();
             type.getElementTypeAction().polish(eConfig);
         }
@@ -158,7 +158,7 @@ public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
      */
     @SuppressWarnings("unchecked")
 	public void syncProcessedConfigs() {
-    	for(ExtendedConfig<?> eConfig : processedConfigs) {
+    	for(ExtendedConfig<?, ?> eConfig : processedConfigs) {
     		// Re-save additional properties
             for(ConfigProperty configProperty : eConfig.configProperties) {
                 configProperty.save(config, false);
@@ -191,7 +191,7 @@ public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
 	 * Get the map of config nameid to config.
 	 * @return The dictionary.
 	 */
-	public Map<String, ExtendedConfig<?>> getDictionary() {
+	public Map<String, ExtendedConfig<?, ?>> getDictionary() {
 		return configDictionary;
 	}
 	
@@ -202,13 +202,13 @@ public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
 	 */
 	public static class ConfigInitListener implements IInitListener {
 
-		private ExtendedConfig<?> config;
+		private ExtendedConfig<?, ?> config;
 		
 		/**
 		 * Make a new instance.
 		 * @param config The config.
 		 */
-		public ConfigInitListener(ExtendedConfig<?> config) {
+		public ConfigInitListener(ExtendedConfig<?, ?> config) {
 			this.config = config;
 		}
 		
@@ -232,9 +232,9 @@ public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
      * @param config The config to check.
      * @return If the given config is enabled.
      */
-    public static boolean isEnabled(Class<? extends ExtendedConfig<?>> config) {
+    public static boolean isEnabled(Class<? extends ExtendedConfig<?, ?>> config) {
         try {
-            return ((ExtendedConfig<?>)config.getField("_instance").get(null)).isEnabled();
+            return ((ExtendedConfig<?, ?>)config.getField("_instance").get(null)).isEnabled();
         } catch (NullPointerException e1) {
             return false;
         } catch (IllegalArgumentException e2) {
@@ -254,7 +254,7 @@ public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
      * @param item The item, possibly IConfigurable.
      * @return The config or null.
      */
-    public static @Nullable ExtendedConfig<?> getConfigFromItem(Item item) {
+    public static @Nullable ExtendedConfig<?, ?> getConfigFromItem(Item item) {
         if(item instanceof IConfigurable) {
             return ((IConfigurable) item).getConfig();
         } else {
@@ -272,7 +272,7 @@ public class ConfigHandler extends LinkedHashSet<ExtendedConfig<?>> {
      * @param fluid The fluid, possibly IConfigurable.
      * @return The config or null.
      */
-    public static @Nullable ExtendedConfig<?> getConfigFromFluid(Fluid fluid) {
+    public static @Nullable ExtendedConfig<?, ?> getConfigFromFluid(Fluid fluid) {
         if(fluid instanceof IConfigurable) {
             return ((IConfigurable) fluid).getConfig();
         }

--- a/src/main/java/org/cyclops/cyclopscore/config/UndisableableConfigException.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/UndisableableConfigException.java
@@ -19,7 +19,7 @@ public class UndisableableConfigException extends CyclopsCoreConfigException {
      * Make a new instance of the exception.
      * @param eConfig The config that caused the exception and was thus disabled.
      */
-    public UndisableableConfigException(ExtendedConfig<?> eConfig) {
+    public UndisableableConfigException(ExtendedConfig<?, ?> eConfig) {
         super("The configuration for "+eConfig.getNamedId()+" was disabled in the config file, please enable it back since this mod can't function without it.");
     }
 }

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBiome.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBiome.java
@@ -37,7 +37,7 @@ public class ConfigurableBiome extends Biome implements IConfigurable {
     }
 
     @Override
-    public ExtendedConfig<?, ?> getConfig() {
+    public ExtendedConfig<BiomeConfig, Biome> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBiome.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBiome.java
@@ -32,12 +32,12 @@ public class ConfigurableBiome extends Biome implements IConfigurable {
         return new Properties(L10NHelpers.localize(eConfig.getUnlocalizedName()));
     }
     
-    private void setConfig(ExtendedConfig<BiomeConfig> eConfig) {
+    private void setConfig(ExtendedConfig<BiomeConfig, Biome> eConfig) {
         this.eConfig = (BiomeConfig)eConfig;
     }
 
     @Override
-    public ExtendedConfig<?> getConfig() {
+    public ExtendedConfig<?, ?> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlock.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlock.java
@@ -49,7 +49,7 @@ public class ConfigurableBlock extends Block implements IConfigurableBlock, IDyn
      * @param eConfig Config for this blockState.
      * @param material Material of this blockState.
      */
-    public ConfigurableBlock(ExtendedConfig<BlockConfig> eConfig, Material material) {
+    public ConfigurableBlock(ExtendedConfig<BlockConfig, Block> eConfig, Material material) {
         super(material);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
@@ -81,12 +81,12 @@ public class ConfigurableBlock extends Block implements IConfigurableBlock, IDyn
         return blockState;
     }
 
-    private void setConfig(ExtendedConfig<BlockConfig> eConfig) {
+    private void setConfig(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.eConfig = (BlockConfig) eConfig;
     }
 
     @Override
-    public ExtendedConfig<BlockConfig> getConfig() {
+    public ExtendedConfig<BlockConfig, Block> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockConnectedTexture.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockConnectedTexture.java
@@ -1,6 +1,8 @@
 package org.cyclops.cyclopscore.config.configurable;
 
 import com.google.common.collect.Maps;
+
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.state.IBlockState;
@@ -68,7 +70,7 @@ public class ConfigurableBlockConnectedTexture extends ConfigurableBlock {
      * @param eConfig  Config for this blockState.
      * @param material Material of this blockState.
      */
-    public ConfigurableBlockConnectedTexture(ExtendedConfig<BlockConfig> eConfig, Material material) {
+    public ConfigurableBlockConnectedTexture(ExtendedConfig<BlockConfig, Block> eConfig, Material material) {
         super(eConfig, material);
 
         if(MinecraftHelpers.isClientSide()) {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockContainer.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockContainer.java
@@ -1,6 +1,7 @@
 package org.cyclops.cyclopscore.config.configurable;
 
 import lombok.experimental.Delegate;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -74,7 +75,7 @@ public class ConfigurableBlockContainer extends BlockContainer implements IConfi
      * @param material Material of this blockState.
      * @param tileEntity The class of the tile entity this blockState holds.
      */
-    public ConfigurableBlockContainer(ExtendedConfig<BlockConfig> eConfig, Material material, Class<? extends CyclopsTileEntity> tileEntity) {
+    public ConfigurableBlockContainer(ExtendedConfig<BlockConfig, Block> eConfig, Material material, Class<? extends CyclopsTileEntity> tileEntity) {
         super(material);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
@@ -118,7 +119,7 @@ public class ConfigurableBlockContainer extends BlockContainer implements IConfi
         return this.tileEntity;
     }
 
-    private void setConfig(ExtendedConfig<BlockConfig> eConfig) {
+    private void setConfig(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.eConfig = (BlockConfig) eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockContainerGui.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockContainerGui.java
@@ -1,5 +1,6 @@
 package org.cyclops.cyclopscore.config.configurable;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -36,7 +37,7 @@ public abstract class ConfigurableBlockContainerGui extends ConfigurableBlockCon
      * @param material Material of this blockState.
      * @param tileEntity The class of the tile entity this blockState holds.
      */
-    public ConfigurableBlockContainerGui(ExtendedConfig<BlockConfig> eConfig,
+    public ConfigurableBlockContainerGui(ExtendedConfig<BlockConfig, Block> eConfig,
             Material material, Class<? extends CyclopsTileEntity> tileEntity) {
         super(eConfig, material, tileEntity);
         this.hasGui = true;

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockFluidClassic.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockFluidClassic.java
@@ -1,5 +1,6 @@
 package org.cyclops.cyclopscore.config.configurable;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.color.IBlockColor;
@@ -13,6 +14,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.block.component.IEntityDropParticleFXBlock;
 import org.cyclops.cyclopscore.block.component.ParticleDropBlockComponent;
+import org.cyclops.cyclopscore.config.extendedconfig.BlockConfig;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
 
 import javax.annotation.Nonnull;
@@ -28,7 +30,7 @@ public abstract class ConfigurableBlockFluidClassic extends BlockFluidClassic im
     
 	private Fluid fluid;
 	
-    protected ExtendedConfig<?, ?> eConfig = null;
+    protected ExtendedConfig<BlockConfig, Block> eConfig = null;
     protected boolean hasGui = false;
     
     @SideOnly(Side.CLIENT)
@@ -40,7 +42,7 @@ public abstract class ConfigurableBlockFluidClassic extends BlockFluidClassic im
      * @param fluid The fluid this blockState has to represent
      * @param material Material of this blockState.
      */
-    public ConfigurableBlockFluidClassic(ExtendedConfig<?, ?> eConfig, Fluid fluid, Material material) {
+    public ConfigurableBlockFluidClassic(ExtendedConfig<BlockConfig, Block> eConfig, Fluid fluid, Material material) {
         super(fluid, material);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
@@ -73,12 +75,12 @@ public abstract class ConfigurableBlockFluidClassic extends BlockFluidClassic im
         return this.fluid;
     }
 
-    private void setConfig(ExtendedConfig<?, ?> eConfig) {
+    private void setConfig(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<?, ?> getConfig() {
+    public ExtendedConfig<BlockConfig, Block> getConfig() {
         return eConfig;
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockFluidClassic.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockFluidClassic.java
@@ -80,7 +80,7 @@ public abstract class ConfigurableBlockFluidClassic extends BlockFluidClassic im
     }
 
     @Override
-    public ExtendedConfig<?> getConfig() {
+    public ExtendedConfig<?, ?> getConfig() {
         return eConfig;
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockFluidClassic.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockFluidClassic.java
@@ -28,8 +28,7 @@ public abstract class ConfigurableBlockFluidClassic extends BlockFluidClassic im
     
 	private Fluid fluid;
 	
-    @SuppressWarnings("rawtypes")
-    protected ExtendedConfig eConfig = null;
+    protected ExtendedConfig<?, ?> eConfig = null;
     protected boolean hasGui = false;
     
     @SideOnly(Side.CLIENT)
@@ -41,8 +40,7 @@ public abstract class ConfigurableBlockFluidClassic extends BlockFluidClassic im
      * @param fluid The fluid this blockState has to represent
      * @param material Material of this blockState.
      */
-    @SuppressWarnings({ "rawtypes" })
-    public ConfigurableBlockFluidClassic(ExtendedConfig eConfig, Fluid fluid, Material material) {
+    public ConfigurableBlockFluidClassic(ExtendedConfig<?, ?> eConfig, Fluid fluid, Material material) {
         super(fluid, material);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
@@ -75,7 +73,7 @@ public abstract class ConfigurableBlockFluidClassic extends BlockFluidClassic im
         return this.fluid;
     }
 
-    private void setConfig(@SuppressWarnings("rawtypes") ExtendedConfig eConfig) {
+    private void setConfig(ExtendedConfig<?, ?> eConfig) {
         this.eConfig = eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockGui.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockGui.java
@@ -1,5 +1,6 @@
 package org.cyclops.cyclopscore.config.configurable;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -28,7 +29,7 @@ public abstract class ConfigurableBlockGui extends ConfigurableBlock implements 
      * @param eConfig Config for this blockState.
      * @param material Material of this blockState.
      */
-    public ConfigurableBlockGui(ExtendedConfig<BlockConfig> eConfig, Material material) {
+    public ConfigurableBlockGui(ExtendedConfig<BlockConfig, Block> eConfig, Material material) {
         super(eConfig, material);
         this.hasGui = true;
         if(hasGui()) {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLeaves.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLeaves.java
@@ -2,6 +2,7 @@ package org.cyclops.cyclopscore.config.configurable;
 
 import com.google.common.collect.Lists;
 import lombok.experimental.Delegate;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.BlockPlanks;
 import net.minecraft.block.properties.IProperty;
@@ -22,6 +23,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.block.property.BlockProperty;
 import org.cyclops.cyclopscore.block.property.BlockPropertyManagerComponent;
 import org.cyclops.cyclopscore.block.property.IBlockPropertyManager;
+import org.cyclops.cyclopscore.config.extendedconfig.BlockConfig;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
 import org.cyclops.cyclopscore.helper.BlockHelpers;
 
@@ -45,14 +47,14 @@ public abstract class ConfigurableBlockLeaves extends BlockLeaves implements ICo
     @BlockProperty(ignore = true)
     public static final IProperty[] _COMPAT = {DECAYABLE, CHECK_DECAY};
 
-    protected ExtendedConfig<?, ?> eConfig = null;
+    protected ExtendedConfig<BlockConfig, Block> eConfig = null;
     protected boolean hasGui = false;
     
     /**
      * Make a new blockState instance.
      * @param eConfig Config for this blockState.
      */
-    public ConfigurableBlockLeaves(ExtendedConfig<?, ?> eConfig) {
+    public ConfigurableBlockLeaves(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
     }
@@ -69,12 +71,12 @@ public abstract class ConfigurableBlockLeaves extends BlockLeaves implements ICo
         return hasGui;
     }
 
-    private void setConfig(ExtendedConfig<?, ?> eConfig) {
+    private void setConfig(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<?, ?> getConfig() {
+    public ExtendedConfig<BlockConfig, Block> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLeaves.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLeaves.java
@@ -76,7 +76,7 @@ public abstract class ConfigurableBlockLeaves extends BlockLeaves implements ICo
     }
 
     @Override
-    public ExtendedConfig<?> getConfig() {
+    public ExtendedConfig<?, ?> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLeaves.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLeaves.java
@@ -45,16 +45,14 @@ public abstract class ConfigurableBlockLeaves extends BlockLeaves implements ICo
     @BlockProperty(ignore = true)
     public static final IProperty[] _COMPAT = {DECAYABLE, CHECK_DECAY};
 
-    @SuppressWarnings("rawtypes")
-    protected ExtendedConfig eConfig = null;
+    protected ExtendedConfig<?, ?> eConfig = null;
     protected boolean hasGui = false;
     
     /**
      * Make a new blockState instance.
      * @param eConfig Config for this blockState.
      */
-    @SuppressWarnings({ "rawtypes" })
-    public ConfigurableBlockLeaves(ExtendedConfig eConfig) {
+    public ConfigurableBlockLeaves(ExtendedConfig<?, ?> eConfig) {
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
     }
@@ -71,7 +69,7 @@ public abstract class ConfigurableBlockLeaves extends BlockLeaves implements ICo
         return hasGui;
     }
 
-    private void setConfig(@SuppressWarnings("rawtypes") ExtendedConfig eConfig) {
+    private void setConfig(ExtendedConfig<?, ?> eConfig) {
         this.eConfig = eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLog.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLog.java
@@ -41,16 +41,14 @@ public class ConfigurableBlockLog extends BlockLog implements IConfigurableBlock
     @BlockProperty
     public static final IProperty[] _COMPAT = {LOG_AXIS};
 
-    @SuppressWarnings("rawtypes")
-    protected ExtendedConfig eConfig = null;
+    protected ExtendedConfig<?, ?> eConfig = null;
     protected boolean hasGui = false;
 
     /**
      * Make a new blockState instance.
      * @param eConfig Config for this blockState.
      */
-    @SuppressWarnings({ "rawtypes" })
-    public ConfigurableBlockLog(ExtendedConfig eConfig) {
+    public ConfigurableBlockLog(ExtendedConfig<?, ?> eConfig) {
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
     }
@@ -67,8 +65,7 @@ public class ConfigurableBlockLog extends BlockLog implements IConfigurableBlock
         return null;
     }
 
-    @SuppressWarnings("rawtypes")
-    private void setConfig(ExtendedConfig eConfig) {
+    private void setConfig(ExtendedConfig<?, ?> eConfig) {
         this.eConfig = eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLog.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLog.java
@@ -1,6 +1,7 @@
 package org.cyclops.cyclopscore.config.configurable;
 
 import lombok.experimental.Delegate;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockLog;
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.BlockStateContainer;
@@ -18,6 +19,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.block.property.BlockProperty;
 import org.cyclops.cyclopscore.block.property.BlockPropertyManagerComponent;
 import org.cyclops.cyclopscore.block.property.IBlockPropertyManager;
+import org.cyclops.cyclopscore.config.extendedconfig.BlockConfig;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
 import org.cyclops.cyclopscore.helper.BlockHelpers;
 
@@ -41,14 +43,14 @@ public class ConfigurableBlockLog extends BlockLog implements IConfigurableBlock
     @BlockProperty
     public static final IProperty[] _COMPAT = {LOG_AXIS};
 
-    protected ExtendedConfig<?, ?> eConfig = null;
+    protected ExtendedConfig<BlockConfig, Block> eConfig = null;
     protected boolean hasGui = false;
 
     /**
      * Make a new blockState instance.
      * @param eConfig Config for this blockState.
      */
-    public ConfigurableBlockLog(ExtendedConfig<?, ?> eConfig) {
+    public ConfigurableBlockLog(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
     }
@@ -65,12 +67,12 @@ public class ConfigurableBlockLog extends BlockLog implements IConfigurableBlock
         return null;
     }
 
-    private void setConfig(ExtendedConfig<?, ?> eConfig) {
+    private void setConfig(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<?, ?> getConfig() {
+    public ExtendedConfig<BlockConfig, Block> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLog.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockLog.java
@@ -73,7 +73,7 @@ public class ConfigurableBlockLog extends BlockLog implements IConfigurableBlock
     }
 
     @Override
-    public ExtendedConfig<?> getConfig() {
+    public ExtendedConfig<?, ?> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockSapling.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockSapling.java
@@ -1,6 +1,7 @@
 package org.cyclops.cyclopscore.config.configurable;
 
 import lombok.experimental.Delegate;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockSapling;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -18,6 +19,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.block.property.BlockProperty;
 import org.cyclops.cyclopscore.block.property.BlockPropertyManagerComponent;
 import org.cyclops.cyclopscore.block.property.IBlockPropertyManager;
+import org.cyclops.cyclopscore.config.extendedconfig.BlockConfig;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
 import org.cyclops.cyclopscore.helper.BlockHelpers;
 import org.cyclops.cyclopscore.world.gen.WorldGeneratorTree;
@@ -43,7 +45,7 @@ public class ConfigurableBlockSapling extends BlockSapling implements IConfigura
     @BlockProperty(ignore = true)
     public static final IProperty[] _COMPAT_IGNORED = {TYPE};
 
-    protected ExtendedConfig<?, ?> eConfig = null;
+    protected ExtendedConfig<BlockConfig, Block> eConfig = null;
     protected boolean hasGui = false;
 
     private WorldGeneratorTree treeGenerator;
@@ -54,7 +56,7 @@ public class ConfigurableBlockSapling extends BlockSapling implements IConfigura
      * @param material Material of this blockState.
      * @param treeGenerator The world generator of the tree.
      */
-    public ConfigurableBlockSapling(ExtendedConfig<?, ?> eConfig, Material material, WorldGeneratorTree treeGenerator) {
+    public ConfigurableBlockSapling(ExtendedConfig<BlockConfig, Block> eConfig, Material material, WorldGeneratorTree treeGenerator) {
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
         this.treeGenerator = treeGenerator;
@@ -73,12 +75,12 @@ public class ConfigurableBlockSapling extends BlockSapling implements IConfigura
         return null;
     }
 
-    private void setConfig(ExtendedConfig<?, ?> eConfig) {
+    private void setConfig(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<?, ?> getConfig() {
+    public ExtendedConfig<BlockConfig, Block> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockSapling.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockSapling.java
@@ -80,7 +80,7 @@ public class ConfigurableBlockSapling extends BlockSapling implements IConfigura
     }
 
     @Override
-    public ExtendedConfig<?> getConfig() {
+    public ExtendedConfig<?, ?> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockSapling.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockSapling.java
@@ -43,8 +43,7 @@ public class ConfigurableBlockSapling extends BlockSapling implements IConfigura
     @BlockProperty(ignore = true)
     public static final IProperty[] _COMPAT_IGNORED = {TYPE};
 
-    @SuppressWarnings("rawtypes")
-    protected ExtendedConfig eConfig = null;
+    protected ExtendedConfig<?, ?> eConfig = null;
     protected boolean hasGui = false;
 
     private WorldGeneratorTree treeGenerator;
@@ -55,8 +54,7 @@ public class ConfigurableBlockSapling extends BlockSapling implements IConfigura
      * @param material Material of this blockState.
      * @param treeGenerator The world generator of the tree.
      */
-    @SuppressWarnings({ "rawtypes" })
-    public ConfigurableBlockSapling(ExtendedConfig eConfig, Material material, WorldGeneratorTree treeGenerator) {
+    public ConfigurableBlockSapling(ExtendedConfig<?, ?> eConfig, Material material, WorldGeneratorTree treeGenerator) {
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
         this.treeGenerator = treeGenerator;
@@ -75,7 +73,7 @@ public class ConfigurableBlockSapling extends BlockSapling implements IConfigura
         return null;
     }
 
-    private void setConfig(@SuppressWarnings("rawtypes") ExtendedConfig eConfig) {
+    private void setConfig(ExtendedConfig<?, ?> eConfig) {
         this.eConfig = eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockStairs.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockStairs.java
@@ -1,5 +1,6 @@
 package org.cyclops.cyclopscore.config.configurable;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockStairs;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.IBakedModel;
@@ -31,7 +32,7 @@ public class ConfigurableBlockStairs extends BlockStairs implements IConfigurabl
      * @param eConfig Config for this blockState.
      * @param modelState The base model of the stairs
      */
-    public ConfigurableBlockStairs(ExtendedConfig<BlockConfig> eConfig, IBlockState modelState) {
+    public ConfigurableBlockStairs(ExtendedConfig<BlockConfig, Block> eConfig, IBlockState modelState) {
         super(modelState);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
@@ -51,12 +52,12 @@ public class ConfigurableBlockStairs extends BlockStairs implements IConfigurabl
         return null;
     }
 
-    private void setConfig(ExtendedConfig<BlockConfig> eConfig) {
+    private void setConfig(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.eConfig = (BlockConfig) eConfig;
     }
 
     @Override
-    public ExtendedConfig<BlockConfig> getConfig() {
+    public ExtendedConfig<BlockConfig, Block> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockTorch.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockTorch.java
@@ -66,7 +66,7 @@ public class ConfigurableBlockTorch extends BlockTorch implements IConfigurableB
     }
 
     @Override
-    public ExtendedConfig<?> getConfig() {
+    public ExtendedConfig<?, ?> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockTorch.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockTorch.java
@@ -31,16 +31,14 @@ public class ConfigurableBlockTorch extends BlockTorch implements IConfigurableB
     @BlockProperty
     public static final IProperty[] _COMPAT = {FACING};
 
-    @SuppressWarnings("rawtypes")
-    protected ExtendedConfig eConfig = null;
+    protected ExtendedConfig<?, ?> eConfig = null;
     protected boolean hasGui = false;
 
     /**
      * Make a new blockState instance.
      * @param eConfig Config for this blockState.
      */
-    @SuppressWarnings({ "rawtypes" })
-    public ConfigurableBlockTorch(ExtendedConfig eConfig) {
+    public ConfigurableBlockTorch(ExtendedConfig<?, ?> eConfig) {
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
         this.setHardness(0.0F);
@@ -60,8 +58,7 @@ public class ConfigurableBlockTorch extends BlockTorch implements IConfigurableB
         return null;
     }
 
-    @SuppressWarnings("rawtypes")
-    private void setConfig(ExtendedConfig eConfig) {
+    private void setConfig(ExtendedConfig<?, ?> eConfig) {
         this.eConfig = eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockTorch.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockTorch.java
@@ -1,6 +1,7 @@
 package org.cyclops.cyclopscore.config.configurable;
 
 import lombok.experimental.Delegate;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockTorch;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.properties.IProperty;
@@ -11,6 +12,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.block.property.BlockProperty;
 import org.cyclops.cyclopscore.block.property.BlockPropertyManagerComponent;
 import org.cyclops.cyclopscore.block.property.IBlockPropertyManager;
+import org.cyclops.cyclopscore.config.extendedconfig.BlockConfig;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
 
 import javax.annotation.Nullable;
@@ -31,14 +33,14 @@ public class ConfigurableBlockTorch extends BlockTorch implements IConfigurableB
     @BlockProperty
     public static final IProperty[] _COMPAT = {FACING};
 
-    protected ExtendedConfig<?, ?> eConfig = null;
+    protected ExtendedConfig<BlockConfig, Block> eConfig = null;
     protected boolean hasGui = false;
 
     /**
      * Make a new blockState instance.
      * @param eConfig Config for this blockState.
      */
-    public ConfigurableBlockTorch(ExtendedConfig<?, ?> eConfig) {
+    public ConfigurableBlockTorch(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
         this.setHardness(0.0F);
@@ -58,12 +60,12 @@ public class ConfigurableBlockTorch extends BlockTorch implements IConfigurableB
         return null;
     }
 
-    private void setConfig(ExtendedConfig<?, ?> eConfig) {
+    private void setConfig(ExtendedConfig<BlockConfig, Block> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<?, ?> getConfig() {
+    public ExtendedConfig<BlockConfig, Block> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableDamageIndicatedItemFluidContainer.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableDamageIndicatedItemFluidContainer.java
@@ -64,7 +64,7 @@ public abstract class ConfigurableDamageIndicatedItemFluidContainer extends Dama
     }
 
     @Override
-    public ExtendedConfig<?> getConfig() {
+    public ExtendedConfig<?, ?> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableDamageIndicatedItemFluidContainer.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableDamageIndicatedItemFluidContainer.java
@@ -6,6 +6,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
@@ -23,6 +24,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.capability.fluid.IFluidHandlerItemCapacity;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
+import org.cyclops.cyclopscore.config.extendedconfig.ItemConfig;
 import org.cyclops.cyclopscore.helper.FluidHelpers;
 import org.cyclops.cyclopscore.helper.L10NHelpers;
 import org.cyclops.cyclopscore.helper.MinecraftHelpers;
@@ -39,7 +41,7 @@ import java.util.List;
  */
 public abstract class ConfigurableDamageIndicatedItemFluidContainer extends DamageIndicatedItemFluidContainer implements IConfigurable {
 
-    protected ExtendedConfig<?, ?> eConfig = null;
+    protected ExtendedConfig<ItemConfig, Item> eConfig = null;
 
     protected boolean canPickUp = true;
     private boolean placeFluids = false;
@@ -50,18 +52,18 @@ public abstract class ConfigurableDamageIndicatedItemFluidContainer extends Dama
      * @param capacity The capacity for the fluid container this item should have.
      * @param fluid The fluid this container should be able to hold.
      */
-    protected ConfigurableDamageIndicatedItemFluidContainer(ExtendedConfig<?, ?> eConfig, int capacity, Fluid fluid) {
+    protected ConfigurableDamageIndicatedItemFluidContainer(ExtendedConfig<ItemConfig, Item> eConfig, int capacity, Fluid fluid) {
         super(capacity, fluid);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
     }
 
-    private void setConfig(ExtendedConfig<?, ?> eConfig) {
+    private void setConfig(ExtendedConfig<ItemConfig, Item> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<?, ?> getConfig() {
+    public ExtendedConfig<ItemConfig, Item> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableDamageIndicatedItemFluidContainer.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableDamageIndicatedItemFluidContainer.java
@@ -39,8 +39,7 @@ import java.util.List;
  */
 public abstract class ConfigurableDamageIndicatedItemFluidContainer extends DamageIndicatedItemFluidContainer implements IConfigurable {
 
-    @SuppressWarnings("rawtypes")
-    protected ExtendedConfig eConfig = null;
+    protected ExtendedConfig<?, ?> eConfig = null;
 
     protected boolean canPickUp = true;
     private boolean placeFluids = false;
@@ -51,15 +50,13 @@ public abstract class ConfigurableDamageIndicatedItemFluidContainer extends Dama
      * @param capacity The capacity for the fluid container this item should have.
      * @param fluid The fluid this container should be able to hold.
      */
-    @SuppressWarnings({ "rawtypes" })
-    protected ConfigurableDamageIndicatedItemFluidContainer(ExtendedConfig eConfig, int capacity, Fluid fluid) {
+    protected ConfigurableDamageIndicatedItemFluidContainer(ExtendedConfig<?, ?> eConfig, int capacity, Fluid fluid) {
         super(capacity, fluid);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
     }
 
-    @SuppressWarnings("rawtypes")
-    private void setConfig(ExtendedConfig eConfig) {
+    private void setConfig(ExtendedConfig<?, ?> eConfig) {
         this.eConfig = eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableEnchantment.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableEnchantment.java
@@ -14,7 +14,7 @@ import org.cyclops.cyclopscore.helper.L10NHelpers;
  */
 public class ConfigurableEnchantment extends Enchantment implements IConfigurable {
 
-    protected ExtendedConfig<EnchantmentConfig> eConfig = null;
+    protected ExtendedConfig<EnchantmentConfig, Enchantment> eConfig = null;
     
     /**
      * Make a new Enchantment instance
@@ -23,19 +23,19 @@ public class ConfigurableEnchantment extends Enchantment implements IConfigurabl
      * @param type The type of enchantment
      * @param slots The equipment types on which the enchantment can occur.
      */
-    protected ConfigurableEnchantment(ExtendedConfig<EnchantmentConfig> eConfig, Enchantment.Rarity rarity,
+    protected ConfigurableEnchantment(ExtendedConfig<EnchantmentConfig, Enchantment> eConfig, Enchantment.Rarity rarity,
                                       EnumEnchantmentType type, EntityEquipmentSlot[] slots) {
         super(rarity, type, slots);
         this.setConfig(eConfig);
         this.setName(eConfig.getUnlocalizedName());
     }
     
-    private void setConfig(ExtendedConfig<EnchantmentConfig> eConfig) {
+    private void setConfig(ExtendedConfig<EnchantmentConfig, Enchantment> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<EnchantmentConfig> getConfig() {
+    public ExtendedConfig<EnchantmentConfig, Enchantment> getConfig() {
         return eConfig;
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableFluid.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableFluid.java
@@ -11,24 +11,24 @@ import org.cyclops.cyclopscore.config.extendedconfig.FluidConfig;
  */
 public abstract class ConfigurableFluid extends Fluid implements IConfigurable{
     
-    protected ExtendedConfig<FluidConfig> eConfig = null;
+    protected ExtendedConfig<FluidConfig, Fluid> eConfig = null;
     
     /**
      * Make a new fluid instance.
      * @param eConfig Config for this blockState.
      */
-    protected ConfigurableFluid(ExtendedConfig<FluidConfig> eConfig) {
+    protected ConfigurableFluid(ExtendedConfig<FluidConfig, Fluid> eConfig) {
         super(eConfig.getNamedId(), eConfig.downCast().getIconLocationStill(), eConfig.downCast().getIconLocationFlow());
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
     }
 
-    private void setConfig(ExtendedConfig<FluidConfig> eConfig) {
+    private void setConfig(ExtendedConfig<FluidConfig, Fluid> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<FluidConfig> getConfig() {
+    public ExtendedConfig<FluidConfig, Fluid> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItem.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItem.java
@@ -33,18 +33,18 @@ public class ConfigurableItem extends Item implements IConfigurableItem, IDynami
      * Make a new item instance.
      * @param eConfig Config for this blockState.
      */
-    public ConfigurableItem(ExtendedConfig<ItemConfig> eConfig) {
+    public ConfigurableItem(ExtendedConfig<ItemConfig, Item> eConfig) {
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
         if(MinecraftHelpers.isClientSide() && hasDynamicModel()) MinecraftForge.EVENT_BUS.register(this);
     }
 
-    private void setConfig(ExtendedConfig<ItemConfig> eConfig) {
+    private void setConfig(ExtendedConfig<ItemConfig, Item> eConfig) {
         this.eConfig = (ItemConfig) eConfig;
     }
 
     @Override
-    public ExtendedConfig<ItemConfig> getConfig() {
+    public ExtendedConfig<ItemConfig, Item> getConfig() {
         return eConfig;
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemBucket.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemBucket.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.init.Items;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemBucket;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -14,6 +15,7 @@ import net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
+import org.cyclops.cyclopscore.config.extendedconfig.ItemConfig;
 import org.cyclops.cyclopscore.helper.L10NHelpers;
 
 import javax.annotation.Nullable;
@@ -26,7 +28,7 @@ import java.util.List;
  */
 public class ConfigurableItemBucket extends ItemBucket implements IConfigurableItem {
     
-    protected ExtendedConfig<?, ?> eConfig = null;
+    protected ExtendedConfig<ItemConfig, Item> eConfig = null;
     
     protected boolean canPickUp = true;
 
@@ -38,7 +40,7 @@ public class ConfigurableItemBucket extends ItemBucket implements IConfigurableI
      * @param block The fluid blockState it can pick up.
      * @param fluidStack The filled fluid.
      */
-    public ConfigurableItemBucket(ExtendedConfig<?, ?> eConfig, Block block, FluidStack fluidStack) {
+    public ConfigurableItemBucket(ExtendedConfig<ItemConfig, Item> eConfig, Block block, FluidStack fluidStack) {
         super(block);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
@@ -46,12 +48,12 @@ public class ConfigurableItemBucket extends ItemBucket implements IConfigurableI
         this.fluidStack = fluidStack;
     }
 
-    private void setConfig(ExtendedConfig<?, ?> eConfig) {
+    private void setConfig(ExtendedConfig<ItemConfig, Item> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<?, ?> getConfig() {
+    public ExtendedConfig<ItemConfig, Item> getConfig() {
         return eConfig;
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemBucket.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemBucket.java
@@ -54,7 +54,7 @@ public class ConfigurableItemBucket extends ItemBucket implements IConfigurableI
     }
 
     @Override
-    public ExtendedConfig<?> getConfig() {
+    public ExtendedConfig<?, ?> getConfig() {
         return eConfig;
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemBucket.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemBucket.java
@@ -26,8 +26,7 @@ import java.util.List;
  */
 public class ConfigurableItemBucket extends ItemBucket implements IConfigurableItem {
     
-    @SuppressWarnings("rawtypes")
-    protected ExtendedConfig eConfig = null;
+    protected ExtendedConfig<?, ?> eConfig = null;
     
     protected boolean canPickUp = true;
 
@@ -39,8 +38,7 @@ public class ConfigurableItemBucket extends ItemBucket implements IConfigurableI
      * @param block The fluid blockState it can pick up.
      * @param fluidStack The filled fluid.
      */
-    @SuppressWarnings({ "rawtypes" })
-    public ConfigurableItemBucket(ExtendedConfig eConfig, Block block, FluidStack fluidStack) {
+    public ConfigurableItemBucket(ExtendedConfig<?, ?> eConfig, Block block, FluidStack fluidStack) {
         super(block);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
@@ -48,8 +46,7 @@ public class ConfigurableItemBucket extends ItemBucket implements IConfigurableI
         this.fluidStack = fluidStack;
     }
 
-    @SuppressWarnings("rawtypes")
-    private void setConfig(ExtendedConfig eConfig) {
+    private void setConfig(ExtendedConfig<?, ?> eConfig) {
         this.eConfig = eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemFood.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemFood.java
@@ -2,12 +2,14 @@ package org.cyclops.cyclopscore.config.configurable;
 
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
+import org.cyclops.cyclopscore.config.extendedconfig.ItemConfig;
 import org.cyclops.cyclopscore.helper.L10NHelpers;
 
 import javax.annotation.Nullable;
@@ -20,7 +22,7 @@ import java.util.List;
  */
 public class ConfigurableItemFood extends ItemFood implements IConfigurableItem {
     
-    protected ExtendedConfig<?, ?> eConfig = null;
+    protected ExtendedConfig<ItemConfig, Item> eConfig = null;
     
     /**
      * Make a new blockState instance.
@@ -29,18 +31,18 @@ public class ConfigurableItemFood extends ItemFood implements IConfigurableItem 
      * @param saturationModifier The modifier for the saturation.
      * @param isWolfsFavoriteMeat If this is wolf food.
      */
-    public ConfigurableItemFood(ExtendedConfig<?, ?> eConfig, int healAmount, float saturationModifier, boolean isWolfsFavoriteMeat) {
+    public ConfigurableItemFood(ExtendedConfig<ItemConfig, Item> eConfig, int healAmount, float saturationModifier, boolean isWolfsFavoriteMeat) {
         super(healAmount, saturationModifier, isWolfsFavoriteMeat);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
     }
 
-    private void setConfig(ExtendedConfig<?, ?> eConfig) {
+    private void setConfig(ExtendedConfig<ItemConfig, Item> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<?, ?> getConfig() {
+    public ExtendedConfig<ItemConfig, Item> getConfig() {
         return eConfig;
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemFood.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemFood.java
@@ -43,7 +43,7 @@ public class ConfigurableItemFood extends ItemFood implements IConfigurableItem 
     }
 
     @Override
-    public ExtendedConfig<?> getConfig() {
+    public ExtendedConfig<?, ?> getConfig() {
         return eConfig;
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemFood.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableItemFood.java
@@ -20,8 +20,7 @@ import java.util.List;
  */
 public class ConfigurableItemFood extends ItemFood implements IConfigurableItem {
     
-    @SuppressWarnings("rawtypes")
-    protected ExtendedConfig eConfig = null;
+    protected ExtendedConfig<?, ?> eConfig = null;
     
     /**
      * Make a new blockState instance.
@@ -30,15 +29,13 @@ public class ConfigurableItemFood extends ItemFood implements IConfigurableItem 
      * @param saturationModifier The modifier for the saturation.
      * @param isWolfsFavoriteMeat If this is wolf food.
      */
-    @SuppressWarnings({ "rawtypes" })
-    public ConfigurableItemFood(ExtendedConfig eConfig, int healAmount, float saturationModifier, boolean isWolfsFavoriteMeat) {
+    public ConfigurableItemFood(ExtendedConfig<?, ?> eConfig, int healAmount, float saturationModifier, boolean isWolfsFavoriteMeat) {
         super(healAmount, saturationModifier, isWolfsFavoriteMeat);
         this.setConfig(eConfig);
         this.setUnlocalizedName(eConfig.getUnlocalizedName());
     }
 
-    @SuppressWarnings("rawtypes")
-    private void setConfig(ExtendedConfig eConfig) {
+    private void setConfig(ExtendedConfig<?, ?> eConfig) {
         this.eConfig = eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurablePotion.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurablePotion.java
@@ -21,7 +21,7 @@ public abstract class ConfigurablePotion extends Potion implements IConfigurable
 
     private final ResourceLocation resource;
 
-    protected ExtendedConfig<PotionConfig> eConfig = null;
+    protected ExtendedConfig<PotionConfig, Potion> eConfig = null;
 
     /**
      * Make a new Enchantment instance
@@ -30,7 +30,7 @@ public abstract class ConfigurablePotion extends Potion implements IConfigurable
      * @param color The color of the potion.
      * @param iconIndex The sprite index of the icon.
      */
-    protected ConfigurablePotion(ExtendedConfig<PotionConfig> eConfig, boolean badEffect, int color, int iconIndex) {
+    protected ConfigurablePotion(ExtendedConfig<PotionConfig, Potion> eConfig, boolean badEffect, int color, int iconIndex) {
         super(badEffect, color);
         this.setConfig(eConfig);
         this.setPotionName(eConfig.getUnlocalizedName());
@@ -46,12 +46,12 @@ public abstract class ConfigurablePotion extends Potion implements IConfigurable
         return super.getStatusIconIndex();
     }
 
-    private void setConfig(ExtendedConfig<PotionConfig> eConfig) {
+    private void setConfig(ExtendedConfig<PotionConfig, Potion> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<PotionConfig> getConfig() {
+    public ExtendedConfig<PotionConfig, Potion> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableVillager.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableVillager.java
@@ -11,25 +11,25 @@ import org.cyclops.cyclopscore.init.ModBase;
  */
 public class ConfigurableVillager extends VillagerRegistry.VillagerProfession implements IConfigurable {
 
-    protected ExtendedConfig<VillagerConfig> eConfig = null;
+    protected ExtendedConfig<VillagerConfig, ConfigurableVillager> eConfig = null;
     
     /**
      * Make a new instance of a villager.
      * @param eConfig The config for this villager.
      */
-    protected ConfigurableVillager(ExtendedConfig<VillagerConfig> eConfig) {
+    protected ConfigurableVillager(ExtendedConfig<VillagerConfig, ConfigurableVillager> eConfig) {
         super(eConfig.getMod()+ ":" + eConfig.getNamedId(),
                 eConfig.getMod() + ":" + eConfig.getMod().getReferenceValue(ModBase.REFKEY_TEXTURE_PATH_SKINS) + eConfig.getNamedId() + ".png",
                 eConfig.getMod() + ":" + eConfig.getMod().getReferenceValue(ModBase.REFKEY_TEXTURE_PATH_SKINS) + eConfig.getNamedId() + "-zombie.png");
         this.setConfig(eConfig);
     }
     
-    private void setConfig(ExtendedConfig<VillagerConfig> eConfig) {
+    private void setConfig(ExtendedConfig<VillagerConfig, ConfigurableVillager> eConfig) {
         this.eConfig = eConfig;
     }
 
     @Override
-    public ExtendedConfig<VillagerConfig> getConfig() {
+    public ExtendedConfig<VillagerConfig, ConfigurableVillager> getConfig() {
         return eConfig;
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/IConfigurable.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/IConfigurable.java
@@ -12,6 +12,6 @@ import org.cyclops.cyclopscore.config.extendedconfig.ExtendedConfig;
  */
 public interface IConfigurable {
 
-    public ExtendedConfig<?> getConfig();
+    public ExtendedConfig<?, ?> getConfig();
 
 }

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BiomeAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BiomeAction.java
@@ -1,5 +1,6 @@
 package org.cyclops.cyclopscore.config.configurabletypeaction;
 
+import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import org.cyclops.cyclopscore.config.extendedconfig.BiomeConfig;
@@ -9,7 +10,7 @@ import org.cyclops.cyclopscore.config.extendedconfig.BiomeConfig;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class BiomeAction extends ConfigurableTypeAction<BiomeConfig>{
+public class BiomeAction extends ConfigurableTypeAction<BiomeConfig, Biome>{
 
     @Override
     public void preRun(BiomeConfig eConfig, Configuration config, boolean startup) {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BlockAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BlockAction.java
@@ -38,7 +38,7 @@ import java.util.concurrent.Callable;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class BlockAction extends ConfigurableTypeAction<BlockConfig> {
+public class BlockAction extends ConfigurableTypeAction<BlockConfig, Block> {
 
     private static final List<BlockConfig> MODEL_ENTRIES = Lists.newArrayList();
 

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BlockAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BlockAction.java
@@ -52,7 +52,7 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig, Block> {
      * @param config The config.
      * @param creativeTabs The creative tab this block will reside in.
      */
-    public static void register(Block block, ExtendedConfig config, @Nullable CreativeTabs creativeTabs) {
+    public static void register(Block block, ExtendedConfig<?, ?> config, @Nullable CreativeTabs creativeTabs) {
         register(block, config, creativeTabs, null);
     }
 
@@ -63,7 +63,7 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig, Block> {
      * @param creativeTabs The creative tab this block will reside in.
      * @param callback A callback that will be called when the entry is registered.
      */
-    public static void register(Block block, ExtendedConfig config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
+    public static void register(Block block, ExtendedConfig<?, ?> config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
         register(block, null, config, creativeTabs, callback);
     }
 
@@ -74,7 +74,7 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig, Block> {
      * @param config The config.
      * @param creativeTabs The creative tab this block will reside in.
      */
-    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig config, @Nullable CreativeTabs creativeTabs) {
+    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig<?, ?> config, @Nullable CreativeTabs creativeTabs) {
         register(block, itemBlockClass, config, creativeTabs, null);
     }
 
@@ -86,7 +86,7 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig, Block> {
      * @param creativeTabs The creative tab this block will reside in.
      * @param callback A callback that will be called when the entry is registered.
      */
-    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
+    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig<?, ?> config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
         register(block, config, (Callable<?>) null); // Delay onForgeRegistered callback until item has been registered
         if(itemBlockClass != null) {
             try {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BlockAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BlockAction.java
@@ -52,7 +52,7 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig, Block> {
      * @param config The config.
      * @param creativeTabs The creative tab this block will reside in.
      */
-    public static void register(Block block, ExtendedConfig<?, ?> config, @Nullable CreativeTabs creativeTabs) {
+    public static void register(Block block, ExtendedConfig<BlockConfig, Block> config, @Nullable CreativeTabs creativeTabs) {
         register(block, config, creativeTabs, null);
     }
 
@@ -63,7 +63,7 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig, Block> {
      * @param creativeTabs The creative tab this block will reside in.
      * @param callback A callback that will be called when the entry is registered.
      */
-    public static void register(Block block, ExtendedConfig<?, ?> config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
+    public static void register(Block block, ExtendedConfig<BlockConfig, Block> config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
         register(block, null, config, creativeTabs, callback);
     }
 
@@ -74,7 +74,7 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig, Block> {
      * @param config The config.
      * @param creativeTabs The creative tab this block will reside in.
      */
-    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig<?, ?> config, @Nullable CreativeTabs creativeTabs) {
+    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig<BlockConfig, Block> config, @Nullable CreativeTabs creativeTabs) {
         register(block, itemBlockClass, config, creativeTabs, null);
     }
 
@@ -86,7 +86,7 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig, Block> {
      * @param creativeTabs The creative tab this block will reside in.
      * @param callback A callback that will be called when the entry is registered.
      */
-    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig<?, ?> config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
+    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig<BlockConfig, Block> config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
         register(block, config, (Callable<?>) null); // Delay onForgeRegistered callback until item has been registered
         if(itemBlockClass != null) {
             try {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/CapabilityAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/CapabilityAction.java
@@ -10,7 +10,7 @@ import org.cyclops.cyclopscore.config.extendedconfig.CapabilityConfig;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class CapabilityAction<T> extends ConfigurableTypeAction<CapabilityConfig<T>> {
+public class CapabilityAction<T> extends ConfigurableTypeAction<CapabilityConfig<T>, T> {
 
     @Override
     public void preRun(CapabilityConfig<T> eConfig, Configuration config, boolean startup) {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/ConfigurableTypeAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/ConfigurableTypeAction.java
@@ -20,14 +20,14 @@ import java.util.concurrent.Callable;
  * @param <C> The subclass of ExtendedConfig
  * @see ConfigHandler
  */
-public abstract class ConfigurableTypeAction<C extends ExtendedConfig<C>> {
+public abstract class ConfigurableTypeAction<C extends ExtendedConfig<C, E>, E> {
     
     /**
      * The common run method for all the subtypes of {@link ConfigurableTypeAction}.
      * @param eConfig The config to be registered.
      * @param config The config file reference.
      */
-    public void commonRun(ExtendedConfig<C> eConfig, Configuration config) {
+    public void commonRun(ExtendedConfig<C, E> eConfig, Configuration config) {
     	if(eConfig.isDisableable()) {
     		preRun(eConfig.downCast(), config, true);
         }
@@ -40,7 +40,7 @@ public abstract class ConfigurableTypeAction<C extends ExtendedConfig<C>> {
         }
     }
     
-    protected void onSkipRegistration(ExtendedConfig<C> eConfig) {
+    protected void onSkipRegistration(ExtendedConfig<C, E> eConfig) {
         eConfig.getMod().log(Level.TRACE, "Skipped registering " + eConfig.getNamedId());
     }
     
@@ -72,7 +72,7 @@ public abstract class ConfigurableTypeAction<C extends ExtendedConfig<C>> {
      * @param config The corresponding config.
      * @param <T> The type to register.
      */
-    public static <T extends IForgeRegistryEntry<T>> void register(T instance, ExtendedConfig<?> config) {
+    public static <T extends IForgeRegistryEntry<T>> void register(T instance, ExtendedConfig<?, ?> config) {
         register(instance, config, () -> {
             config.onForgeRegistered();
             return null;
@@ -86,7 +86,7 @@ public abstract class ConfigurableTypeAction<C extends ExtendedConfig<C>> {
      * @param callback A callback that will be called when the entry is registered.
      * @param <T> The type to register.
      */
-    public static <T extends IForgeRegistryEntry<T>> void register(T instance, ExtendedConfig<?> config, @Nullable Callable<?> callback) {
+    public static <T extends IForgeRegistryEntry<T>> void register(T instance, ExtendedConfig<?, ?> config, @Nullable Callable<?> callback) {
         register(Objects.requireNonNull((IForgeRegistry<T>)config.getRegistry(),
                 "Tried registering a config for which no registry exists: " + config.getNamedId()), instance, config, callback);
     }
@@ -98,7 +98,7 @@ public abstract class ConfigurableTypeAction<C extends ExtendedConfig<C>> {
      * @param config The corresponding config.
      * @param <T> The type to register.
      */
-    public static <T extends IForgeRegistryEntry<T>> void register(IForgeRegistry<T> registry, T instance, ExtendedConfig<?> config) {
+    public static <T extends IForgeRegistryEntry<T>> void register(IForgeRegistry<T> registry, T instance, ExtendedConfig<?, ?> config) {
         register(registry, instance, config, null);
     }
 
@@ -110,7 +110,7 @@ public abstract class ConfigurableTypeAction<C extends ExtendedConfig<C>> {
      * @param callback A callback that will be called when the entry is registered.
      * @param <T> The type to register.
      */
-    public static <T extends IForgeRegistryEntry<T>> void register(IForgeRegistry<T> registry, T instance, ExtendedConfig<?> config, @Nullable Callable<?> callback) {
+    public static <T extends IForgeRegistryEntry<T>> void register(IForgeRegistry<T> registry, T instance, ExtendedConfig<?, ?> config, @Nullable Callable<?> callback) {
         if (instance.getRegistryName() == null) {
             instance.setRegistryName(new ResourceLocation(config.getMod().getModId(), config.getNamedId()));
         }

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/DummyAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/DummyAction.java
@@ -8,7 +8,7 @@ import org.cyclops.cyclopscore.config.extendedconfig.DummyConfig;
  * @author rubensworks
  *
  */
-public class DummyAction extends ConfigurableTypeAction<DummyConfig> {
+public class DummyAction extends ConfigurableTypeAction<DummyConfig, Object> {
 
     @Override
     public void preRun(DummyConfig eConfig, Configuration config, boolean startup) {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/EnchantmentAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/EnchantmentAction.java
@@ -1,5 +1,6 @@
 package org.cyclops.cyclopscore.config.configurabletypeaction;
 
+import net.minecraft.enchantment.Enchantment;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import org.cyclops.cyclopscore.config.extendedconfig.EnchantmentConfig;
@@ -9,7 +10,7 @@ import org.cyclops.cyclopscore.config.extendedconfig.EnchantmentConfig;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class EnchantmentAction extends ConfigurableTypeAction<EnchantmentConfig>{
+public class EnchantmentAction extends ConfigurableTypeAction<EnchantmentConfig, Enchantment>{
 
     @Override
     public void preRun(EnchantmentConfig eConfig, Configuration config, boolean startup) {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/EntityAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/EntityAction.java
@@ -13,14 +13,13 @@ import org.cyclops.cyclopscore.helper.Helpers;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class EntityAction<T extends Entity> extends ConfigurableTypeAction<EntityConfig<T>>{
+public class EntityAction<T extends Entity> extends ConfigurableTypeAction<EntityConfig<T>, T>{
 
     @Override
     public void preRun(EntityConfig<T> eConfig, Configuration config, boolean startup) {
         
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void postRun(EntityConfig<T> eConfig, Configuration config) {
         // Save the config inside the correct element

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/FluidAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/FluidAction.java
@@ -10,7 +10,7 @@ import org.cyclops.cyclopscore.config.extendedconfig.FluidConfig;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class FluidAction extends ConfigurableTypeAction<FluidConfig>{
+public class FluidAction extends ConfigurableTypeAction<FluidConfig, Fluid>{
 
     @Override
     public void preRun(FluidConfig eConfig, Configuration config, boolean startup) {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/ItemAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/ItemAction.java
@@ -36,9 +36,9 @@ import java.util.List;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class ItemAction extends ConfigurableTypeAction<ItemConfig>{
+public class ItemAction extends ConfigurableTypeAction<ItemConfig, Item>{
 
-    private static final List<ExtendedConfig<?>> MODEL_ENTRIES = Lists.newArrayList();
+    private static final List<ExtendedConfig<?, ?>> MODEL_ENTRIES = Lists.newArrayList();
 
     static {
         MinecraftForge.EVENT_BUS.register(ItemAction.class);
@@ -50,7 +50,7 @@ public class ItemAction extends ConfigurableTypeAction<ItemConfig>{
      * @param config The config.
      * @param creativeTabs The creative tab this block will reside in.
      */
-    public static void register(Item item, ExtendedConfig<?> config, @Nullable CreativeTabs creativeTabs) {
+    public static void register(Item item, ExtendedConfig<?, ?> config, @Nullable CreativeTabs creativeTabs) {
         register(item, config);
 
         if(creativeTabs != null) {
@@ -97,7 +97,7 @@ public class ItemAction extends ConfigurableTypeAction<ItemConfig>{
     @SideOnly(Side.CLIENT)
     @SubscribeEvent
     public static void onModelRegistryLoad(ModelRegistryEvent event) {
-        for (ExtendedConfig<?> entry : MODEL_ENTRIES) {
+        for (ExtendedConfig<?, ?> entry : MODEL_ENTRIES) {
             Item item = null;
             Block block = null;
             IModelProviderConfig modelProvider = null;
@@ -134,7 +134,7 @@ public class ItemAction extends ConfigurableTypeAction<ItemConfig>{
         }
     }
 
-    public static void handleItemModel(ExtendedConfig<?> extendedConfig) {
+    public static void handleItemModel(ExtendedConfig<?, ?> extendedConfig) {
         if(MinecraftHelpers.isClientSide()) {
             MODEL_ENTRIES.add(extendedConfig);
         }

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/MobAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/MobAction.java
@@ -14,14 +14,13 @@ import org.cyclops.cyclopscore.helper.Helpers;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class MobAction<T extends Entity> extends ConfigurableTypeAction<MobConfig<T>>{
+public class MobAction<T extends EntityLiving> extends ConfigurableTypeAction<MobConfig<T>, T>{
 
     @Override
     public void preRun(MobConfig<T> eConfig, Configuration config, boolean startup) {
         
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void postRun(MobConfig<T> eConfig, Configuration config) {
         // Save the config inside the correct element

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/PotionAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/PotionAction.java
@@ -1,5 +1,6 @@
 package org.cyclops.cyclopscore.config.configurabletypeaction;
 
+import net.minecraft.potion.Potion;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.config.Property;
 import org.cyclops.cyclopscore.config.extendedconfig.PotionConfig;
@@ -9,7 +10,7 @@ import org.cyclops.cyclopscore.config.extendedconfig.PotionConfig;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class PotionAction extends ConfigurableTypeAction<PotionConfig> {
+public class PotionAction extends ConfigurableTypeAction<PotionConfig, Potion> {
 
     @Override
     public void preRun(PotionConfig eConfig, Configuration config, boolean startup) {

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/VillagerAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/VillagerAction.java
@@ -10,7 +10,7 @@ import org.cyclops.cyclopscore.config.extendedconfig.VillagerConfig;
  * @author rubensworks
  * @see ConfigurableTypeAction
  */
-public class VillagerAction extends ConfigurableTypeAction<VillagerConfig>{
+public class VillagerAction extends ConfigurableTypeAction<VillagerConfig, ConfigurableVillager>{
 
     @Override
     public void preRun(VillagerConfig eConfig, Configuration config, boolean startup) {

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BiomeConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BiomeConfig.java
@@ -13,7 +13,7 @@ import org.cyclops.cyclopscore.init.ModBase;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class BiomeConfig extends ExtendedConfig<BiomeConfig>{
+public abstract class BiomeConfig extends ExtendedConfig<BiomeConfig, Biome>{
 
     /**
      * Make a new instance.

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockConfig.java
@@ -26,7 +26,7 @@ import org.cyclops.cyclopscore.item.ItemBlockMetadata;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class BlockConfig extends ExtendedConfig<BlockConfig> implements IModelProviderConfig {
+public abstract class BlockConfig extends ExtendedConfig<BlockConfig, Block> implements IModelProviderConfig {
 
     @SideOnly(Side.CLIENT) public ModelResourceLocation dynamicBlockVariantLocation;
     @SideOnly(Side.CLIENT) public ModelResourceLocation dynamicItemVariantLocation;

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/CapabilityConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/CapabilityConfig.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class CapabilityConfig<T> extends ExtendedConfig<CapabilityConfig<T>> {
+public abstract class CapabilityConfig<T> extends ExtendedConfig<CapabilityConfig<T>, T> {
 
     private final Class<T> type;
     private final Capability.IStorage<T> storage;

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/DummyConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/DummyConfig.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
  * @see ExtendedConfig
  *
  */
-public class DummyConfig extends ExtendedConfig<DummyConfig>{
+public class DummyConfig extends ExtendedConfig<DummyConfig, Object>{
 
     /**
      * Make a new instance.

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/EnchantmentConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/EnchantmentConfig.java
@@ -12,7 +12,7 @@ import org.cyclops.cyclopscore.init.ModBase;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class EnchantmentConfig extends ExtendedConfig<EnchantmentConfig>{
+public abstract class EnchantmentConfig extends ExtendedConfig<EnchantmentConfig, Enchantment>{
 	
     /**
      * Make a new instance.

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/EntityConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/EntityConfig.java
@@ -50,8 +50,7 @@ public abstract class EntityConfig<T extends Entity> extends ExtendedConfig<Enti
     @SideOnly(Side.CLIENT)
     public void onRegistered() {
         super.onRegistered();
-        @SuppressWarnings("unchecked")
-        Class<T> clazz = (Class<T>) this.getElement();
+        Class<? extends T> clazz = this.getElement();
         RenderingRegistry.registerEntityRenderingHandler(clazz, new IRenderFactory<T>() {
             @Override
             public Render<? super T> createRenderFor(RenderManager manager) {

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/EntityConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/EntityConfig.java
@@ -22,7 +22,7 @@ import org.cyclops.cyclopscore.init.ModBase;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class EntityConfig<T extends Entity> extends ExtendedConfig<EntityConfig<T>>{
+public abstract class EntityConfig<T extends Entity> extends ExtendedConfig<EntityConfig<T>, T>{
 
     /**
      * Make a new instance.
@@ -32,7 +32,7 @@ public abstract class EntityConfig<T extends Entity> extends ExtendedConfig<Enti
      * @param comment The comment to add in the config file for this configurable.
      * @param element The class of this configurable.
      */
-    public EntityConfig(ModBase mod, boolean enabled, String namedId, String comment, Class<? extends Entity> element) {
+    public EntityConfig(ModBase mod, boolean enabled, String namedId, String comment, Class<? extends T> element) {
         super(mod, enabled, namedId, comment, element);
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/ExtendedConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/ExtendedConfig.java
@@ -25,14 +25,14 @@ import java.util.Locale;
  * @param <C> Class of the extension of ExtendedConfig
  *
  */
-public abstract class ExtendedConfig<C extends ExtendedConfig<C>> implements
-	Comparable<ExtendedConfig<C>>, IInitListener {
+public abstract class ExtendedConfig<C extends ExtendedConfig<C, E>, E> implements
+	Comparable<ExtendedConfig<C, E>>, IInitListener {
 
     @Getter private final ModBase mod;
     private boolean enabled;
     @Getter private final String namedId;
     @Getter private final String comment;
-    @Getter private final Class<?> element;
+    @Getter private final Class<? extends E> element;
 
     private IConfigurable overriddenSubInstance;
     
@@ -50,7 +50,7 @@ public abstract class ExtendedConfig<C extends ExtendedConfig<C>> implements
      * @param comment a comment that can be added to the config file line
      * @param element the class for the element this config is for
      */
-    public ExtendedConfig(ModBase mod, boolean enabled, String namedId, String comment, Class<?> element) {
+    public ExtendedConfig(ModBase mod, boolean enabled, String namedId, String comment, Class<? extends E> element) {
         this.mod = mod;
     	this.enabled = enabled;
     	this.namedId = namedId.toLowerCase(Locale.ROOT);
@@ -127,12 +127,12 @@ public abstract class ExtendedConfig<C extends ExtendedConfig<C>> implements
 
             // Save inside the unique instance this config refers to (only if such an instance exists!)
             if (getOverriddenSubInstance() == null && this.getHolderType().hasUniqueInstance()) {
-                Constructor<?> constructor = this.getElement().getDeclaredConstructor(ExtendedConfig.class);
+                Constructor<? extends E> constructor = this.getElement().getDeclaredConstructor(ExtendedConfig.class);
                 if(constructor == null) {
                     throw new CyclopsCoreConfigException(String.format("The class %s requires a constructor with " +
                             "ExtendedConfig as single parameter.", this.getElement()));
                 }
-                Object instance = constructor.newInstance(this);
+                E instance = constructor.newInstance(this);
 
                 Field field = this.getElement().getDeclaredField("_instance");
                 field.setAccessible(true);
@@ -250,7 +250,7 @@ public abstract class ExtendedConfig<C extends ExtendedConfig<C>> implements
     }
     
     @Override
-    public int compareTo(ExtendedConfig<C> o) {
+    public int compareTo(ExtendedConfig<C, E> o) {
         return getNamedId().compareTo(o.getNamedId());
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/FluidConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/FluidConfig.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class FluidConfig extends ExtendedConfig<FluidConfig> {
+public abstract class FluidConfig extends ExtendedConfig<FluidConfig, Fluid> {
 
     /**
      * Make a new instance.

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/ItemConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/ItemConfig.java
@@ -21,7 +21,7 @@ import org.cyclops.cyclopscore.init.ModBase;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class ItemConfig extends ExtendedConfig<ItemConfig> implements IModelProviderConfig {
+public abstract class ItemConfig extends ExtendedConfig<ItemConfig, Item> implements IModelProviderConfig {
 
     @SideOnly(Side.CLIENT) public ModelResourceLocation dynamicItemVariantLocation;
 

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/MobConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/MobConfig.java
@@ -2,7 +2,7 @@ package org.cyclops.cyclopscore.config.extendedconfig;
 
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderManager;
-import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
 import net.minecraftforge.fml.client.registry.IRenderFactory;
 import net.minecraftforge.fml.client.registry.RenderingRegistry;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
@@ -18,7 +18,7 @@ import org.cyclops.cyclopscore.init.ModBase;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class MobConfig<T extends Entity> extends ExtendedConfig<MobConfig<T>> {
+public abstract class MobConfig<T extends EntityLiving> extends ExtendedConfig<MobConfig<T>, T> {
 
     /**
      * Make a new instance.
@@ -28,7 +28,7 @@ public abstract class MobConfig<T extends Entity> extends ExtendedConfig<MobConf
      * @param comment The comment to add in the config file for this configurable.
      * @param element The class of this configurable.
      */
-    public MobConfig(ModBase mod, boolean enabled, String namedId, String comment, Class<?> element) {
+    public MobConfig(ModBase mod, boolean enabled, String namedId, String comment, Class<? extends T> element) {
         super(mod, enabled, namedId, comment, element);
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/MobConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/MobConfig.java
@@ -46,8 +46,7 @@ public abstract class MobConfig<T extends EntityLiving> extends ExtendedConfig<M
     @SideOnly(Side.CLIENT)
     public void onRegistered() {
         super.onRegistered();
-        @SuppressWarnings("unchecked")
-        Class<T> clazz = (Class<T>) this.getElement();
+        Class<? extends T> clazz = this.getElement();
         RenderingRegistry.registerEntityRenderingHandler(clazz, new IRenderFactory<T>() {
             @Override
             public Render<? super T> createRenderFor(RenderManager manager) {

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/ModelEntityConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/ModelEntityConfig.java
@@ -26,7 +26,7 @@ public abstract class ModelEntityConfig<T extends Entity> extends EntityConfig<T
      * @param comment The comment to add in the config file for this configurable.
      * @param element The class of this configurable.
      */
-    public ModelEntityConfig(ModBase mod, boolean enabled, String namedId, String comment, Class<? extends Entity> element) {
+    public ModelEntityConfig(ModBase mod, boolean enabled, String namedId, String comment, Class<? extends T> element) {
         super(mod, enabled, namedId, comment, element);
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/PotionConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/PotionConfig.java
@@ -12,7 +12,7 @@ import org.cyclops.cyclopscore.init.ModBase;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class PotionConfig extends ExtendedConfig<PotionConfig> {
+public abstract class PotionConfig extends ExtendedConfig<PotionConfig, Potion> {
 
     /**
      * Make a new instance.

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/VillagerConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/VillagerConfig.java
@@ -11,7 +11,7 @@ import org.cyclops.cyclopscore.init.ModBase;
  * @author rubensworks
  * @see ExtendedConfig
  */
-public abstract class VillagerConfig extends ExtendedConfig<VillagerConfig> {
+public abstract class VillagerConfig extends ExtendedConfig<VillagerConfig, ConfigurableVillager> {
 
     /**
      * Make a new instance.

--- a/src/main/java/org/cyclops/cyclopscore/infobook/InfoSectionTagIndex.java
+++ b/src/main/java/org/cyclops/cyclopscore/infobook/InfoSectionTagIndex.java
@@ -58,7 +58,7 @@ public class InfoSectionTagIndex extends InfoSection {
                 throw new IllegalArgumentException("The tag " + tag + " occurs multiple times.");
             }
 
-            ExtendedConfig<?> config = mod.getConfigHandler().getDictionary().get(tag);
+            ExtendedConfig<?, ?> config = mod.getConfigHandler().getDictionary().get(tag);
             if(config != null) {
                 softLinks.put(config.getFullUnlocalizedName(), Pair.of(section, 0));
             }

--- a/src/main/java/org/cyclops/cyclopscore/infobook/pageelement/RecipeAppendix.java
+++ b/src/main/java/org/cyclops/cyclopscore/infobook/pageelement/RecipeAppendix.java
@@ -271,7 +271,7 @@ public abstract class RecipeAppendix<T> extends SectionAppendix {
             this.element = element;
             InfoSection target = null;
             if(this.element != null) {
-                ExtendedConfig<?> config = getConfigFromElement(element);
+                ExtendedConfig<?, ?> config = getConfigFromElement(element);
                 if (config != null) {
                     Pair<InfoSection, Integer> pair = this.infoBook.getConfigLinks().get(config.getFullUnlocalizedName());
                     if(pair != null) {
@@ -282,7 +282,7 @@ public abstract class RecipeAppendix<T> extends SectionAppendix {
             super.update(x, y, "empty", target, gui);
         }
 
-        protected abstract ExtendedConfig<?> getConfigFromElement(E element);
+        protected abstract ExtendedConfig<?, ?> getConfigFromElement(E element);
 
         @Override
         public void drawButton(Minecraft minecraft, int mouseX, int mouseY, float partialTicks) {
@@ -314,7 +314,7 @@ public abstract class RecipeAppendix<T> extends SectionAppendix {
         }
 
         @Override
-        protected ExtendedConfig<?> getConfigFromElement(ItemStack element) {
+        protected ExtendedConfig<?, ?> getConfigFromElement(ItemStack element) {
             return ConfigHandler.getConfigFromItem(element.getItem());
         }
     }
@@ -326,7 +326,7 @@ public abstract class RecipeAppendix<T> extends SectionAppendix {
         }
 
         @Override
-        protected ExtendedConfig<?> getConfigFromElement(FluidStack element) {
+        protected ExtendedConfig<?, ?> getConfigFromElement(FluidStack element) {
             return ConfigHandler.getConfigFromFluid(element.getFluid());
         }
 

--- a/src/main/java/org/cyclops/cyclopscore/init/Debug.java
+++ b/src/main/java/org/cyclops/cyclopscore/init/Debug.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public class Debug {
     
     private static final String CONFIGCHECKER_PREFIX = "[CONFIGCHECKER] ";
-    private final Set<ExtendedConfig<?>> savedConfigs = Sets.newHashSet();
+    private final Set<ExtendedConfig<?, ?>> savedConfigs = Sets.newHashSet();
     private final ModBase mod;
     
     private boolean ok = true;
@@ -27,8 +27,8 @@ public class Debug {
      * Loops over the list of configs and checks their correctness.
      * @param configs List of configs
      */
-    public void checkPreConfigurables(Set<ExtendedConfig<?>> configs) {
-        for(ExtendedConfig<?> config : configs) {
+    public void checkPreConfigurables(Set<ExtendedConfig<?, ?>> configs) {
+        for(ExtendedConfig<?, ?> config : configs) {
             // _instance field on ExtendedConfig
             try {
                 config.getClass().getField("_instance");
@@ -47,7 +47,7 @@ public class Debug {
      * Loops over the list of configs (was saved from the Pre call) and checks their correctness.
      */
     public void checkPostConfigurables() {
-        for(ExtendedConfig<?> config : savedConfigs) {
+        for(ExtendedConfig<?, ?> config : savedConfigs) {
             if(config.getHolderType().hasUniqueInstance() && config.isEnabled()) {
                 // The sub-instance of ExtendedConfig (can be in a higher class hierarchy, bit of a hack...
                 if(config.getSubInstance() == null) {

--- a/src/main/java/org/cyclops/cyclopscore/init/ModBase.java
+++ b/src/main/java/org/cyclops/cyclopscore/init/ModBase.java
@@ -380,7 +380,7 @@ public abstract class ModBase {
      * The registration order is always kept.
      * @param extendedConfig The config to register.
      */
-    public final void registerConfig(ExtendedConfig<?> extendedConfig) {
+    public final void registerConfig(ExtendedConfig<?, ?> extendedConfig) {
         getConfigHandler().add(extendedConfig);
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/inventory/IGuiContainerProviderConfigurable.java
+++ b/src/main/java/org/cyclops/cyclopscore/inventory/IGuiContainerProviderConfigurable.java
@@ -12,6 +12,6 @@ public interface IGuiContainerProviderConfigurable extends IGuiContainerProvider
     /**
      * @return The configurable config.
      */
-    public ExtendedConfig<?> getConfig();
+    public ExtendedConfig<?, ?> getConfig();
 	
 }

--- a/src/main/java/org/cyclops/cyclopscore/item/ItemGui.java
+++ b/src/main/java/org/cyclops/cyclopscore/item/ItemGui.java
@@ -4,6 +4,7 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.Container;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
@@ -34,7 +35,7 @@ public abstract class ItemGui extends ConfigurableItem implements IGuiContainerP
      * Make a new item instance.
      * @param eConfig Config for this blockState.
      */
-	protected ItemGui(ExtendedConfig<ItemConfig> eConfig) {
+	protected ItemGui(ExtendedConfig<ItemConfig, Item> eConfig) {
 		super(eConfig);
 		this.guiID = Helpers.getNewId(eConfig.getMod(), IDType.GUI);
 	}

--- a/src/main/java/org/cyclops/cyclopscore/recipe/xml/ConfigRecipeConditionHandler.java
+++ b/src/main/java/org/cyclops/cyclopscore/recipe/xml/ConfigRecipeConditionHandler.java
@@ -12,7 +12,7 @@ public class ConfigRecipeConditionHandler implements IRecipeConditionHandler {
 
 	@Override
 	public boolean isSatisfied(RecipeHandler recipeHandler, String param) {
-		ExtendedConfig<?> config = recipeHandler.getMod().getConfigHandler().getDictionary().get(param);
+		ExtendedConfig<?, ?> config = recipeHandler.getMod().getConfigHandler().getDictionary().get(param);
 		return config != null && config.isEnabled();
 	}
 


### PR DESCRIPTION
This lets us get rid of a lot more raw types and unchecked casts. Note that the way type erasure works, this  breaks source compatibility (though trivial to fix), but shouldn't break binary compatibility.