### PR TITLE
Add support for doors

### DIFF
--- a/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockDoor.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurable/ConfigurableBlockDoor.java
@@ -1,0 +1,86 @@
+package org.cyclops.cyclopscore.config.configurable;
+
+import net.minecraft.block.BlockDoor;
+import net.minecraft.block.SoundType;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.renderer.color.IBlockColor;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import org.cyclops.cyclopscore.config.extendedconfig.BlockDoorConfig;
+
+import java.util.Random;
+
+import javax.annotation.Nullable;
+
+/**
+ * Door blockState that can hold ExtendedConfigs
+ * @author josephcsible
+ *
+ */
+public class ConfigurableBlockDoor extends BlockDoor implements IConfigurableBlock {
+    public Item item;
+
+    // Note the intentional lack of any block state or property related code.
+    // There's only room for 1 more bit of information, and using it would be
+    // exceedingly complex, so code to use it won't be written unless/until a
+    // door actually needs it for something.
+
+    protected BlockDoorConfig eConfig = null;
+    protected boolean hasGui = false;
+
+    /**
+     * Make a new blockState instance.
+     * @param config Config for this blockState.
+     */
+    public ConfigurableBlockDoor(BlockDoorConfig config, Material material) {
+        super(material);
+        setConfig(config);
+        setUnlocalizedName(config.getUnlocalizedName());
+        disableStats();
+    }
+
+    @Override
+    public ItemStack getItem(World world, BlockPos pos, IBlockState state) {
+        return new ItemStack(item);
+    }
+
+    @Override
+    public Item getItemDropped(IBlockState state, Random rand, int fortune)
+    {
+        return state.getValue(HALF) == BlockDoor.EnumDoorHalf.UPPER ? Items.AIR : item;
+    }
+
+    // overriding to make it public instead of protected
+    @Override
+    public ConfigurableBlockDoor setSoundType(SoundType sound) {
+        super.setSoundType(sound);
+        return this;
+    }
+
+    @Override
+    public boolean hasGui() {
+        return hasGui;
+    }
+
+    @Nullable
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IBlockColor getBlockColorHandler() {
+        return null;
+    }
+
+    private void setConfig(BlockDoorConfig eConfig) {
+        this.eConfig = eConfig;
+    }
+
+    @Override
+    public BlockDoorConfig getConfig() {
+        return eConfig;
+    }
+}

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BlockAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/BlockAction.java
@@ -6,7 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.color.IBlockColor;
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.item.ItemBlock;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -74,7 +74,7 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig> {
      * @param config The config.
      * @param creativeTabs The creative tab this block will reside in.
      */
-    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig<BlockConfig> config, @Nullable CreativeTabs creativeTabs) {
+    public static void register(Block block, @Nullable Class<? extends Item> itemBlockClass, ExtendedConfig<BlockConfig> config, @Nullable CreativeTabs creativeTabs) {
         register(block, itemBlockClass, config, creativeTabs, null);
     }
 
@@ -86,11 +86,11 @@ public class BlockAction extends ConfigurableTypeAction<BlockConfig> {
      * @param creativeTabs The creative tab this block will reside in.
      * @param callback A callback that will be called when the entry is registered.
      */
-    public static void register(Block block, @Nullable Class<? extends ItemBlock> itemBlockClass, ExtendedConfig<BlockConfig> config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
+    public static void register(Block block, @Nullable Class<? extends Item> itemBlockClass, ExtendedConfig<BlockConfig> config, @Nullable CreativeTabs creativeTabs, @Nullable Callable<?> callback) {
         register(block, config, (Callable<?>) null); // Delay onForgeRegistered callback until item has been registered
         if(itemBlockClass != null) {
             try {
-                ItemBlock item = itemBlockClass.getConstructor(Block.class).newInstance(block);
+                Item item = itemBlockClass.getConstructor(Block.class).newInstance(block);
                 register(ForgeRegistries.ITEMS, item, config, callback);
             } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
                 e.printStackTrace();

--- a/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/ItemAction.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/configurabletypeaction/ItemAction.java
@@ -106,7 +106,7 @@ public class ItemAction extends ConfigurableTypeAction<ItemConfig>{
                 modelProvider = (IModelProviderConfig) entry;
             } else if (entry instanceof BlockConfig) {
                 block = ((BlockConfig) entry).getBlockInstance();
-                item = Item.getItemFromBlock(block);
+                item = ((BlockConfig) entry).getItemInstance();
                 modelProvider = (IModelProviderConfig) entry;
             } else {
                 throw new IllegalStateException("An unsupported config was registered to the model loader: "

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockConfig.java
@@ -12,6 +12,9 @@ import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.registries.IForgeRegistry;
+
+import javax.annotation.Nonnull;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.cyclops.cyclopscore.client.model.IDynamicModelElement;
 import org.cyclops.cyclopscore.config.ConfigurableType;
@@ -99,6 +102,16 @@ public abstract class BlockConfig extends ExtendedConfig<BlockConfig> implements
     }
 
     /**
+     * Get the item corresponding to the block.
+     * Will return Items.AIR rather than null if there isn't one.
+     * @return The item.
+     */
+    @Nonnull
+    public Item getItemInstance() {
+        return Item.getItemFromBlock(getBlockInstance());
+    }
+
+    /**
      * Get the creative tab for this item.
      * @return The creative tab, by default the value in {@link org.cyclops.cyclopscore.init.ModBase#getDefaultCreativeTab()}.
      */
@@ -122,7 +135,7 @@ public abstract class BlockConfig extends ExtendedConfig<BlockConfig> implements
                 return blockLocation;
             }
         });
-        ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(getBlockInstance()), 0, itemLocation);
+        ModelLoader.setCustomModelResourceLocation(getItemInstance(), 0, itemLocation);
         return Pair.of(blockLocation, itemLocation);
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockConfig.java
@@ -6,7 +6,6 @@ import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.client.renderer.block.statemap.StateMapperBase;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
@@ -71,7 +70,7 @@ public abstract class BlockConfig extends ExtendedConfig<BlockConfig> implements
      * If hasSubTypes() returns true this method can be overwritten to define another ItemBlock class
      * @return the ItemBlock class to use for the target blockState.
      */
-    public Class<? extends ItemBlock> getItemBlockClass() {
+    public Class<? extends Item> getItemBlockClass() {
         return ItemBlockMetadata.class;
     }
     

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockDoorConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockDoorConfig.java
@@ -1,0 +1,48 @@
+package org.cyclops.cyclopscore.config.extendedconfig;
+
+import org.cyclops.cyclopscore.config.configurable.ConfigurableBlockDoor;
+import org.cyclops.cyclopscore.helper.MinecraftHelpers;
+import org.cyclops.cyclopscore.init.ModBase;
+import org.cyclops.cyclopscore.item.ItemDoorMetadata;
+
+import net.minecraft.block.BlockDoor;
+import net.minecraft.client.renderer.block.statemap.StateMap;
+import net.minecraft.item.Item;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+/**
+ * Config for doors.
+ * @author josephcsible
+ * @see ExtendedConfig
+ */
+public abstract class BlockDoorConfig extends BlockConfig {
+    /**
+     * @see org.cyclops.cyclopscore.config.extendedconfig.BlockConfig#BlockConfig(ModBase, boolean, String, String, Class)
+     */
+    public BlockDoorConfig(ModBase mod, boolean enabled, String namedId, String comment, Class<? extends ConfigurableBlockDoor> element) {
+        super(mod, enabled, namedId, comment, element);
+        if(MinecraftHelpers.isClientSide())
+            MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @Override
+    public Class<? extends Item> getItemBlockClass() {
+        return ItemDoorMetadata.class;
+    }
+
+    @Override
+    public Item getItemInstance() {
+        return ((ConfigurableBlockDoor)getBlockInstance()).item;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @SubscribeEvent
+    public void onModelRegistryLoad(ModelRegistryEvent event) {
+        ModelLoader.setCustomStateMapper(getBlockInstance(), (new StateMap.Builder()).ignore(BlockDoor.POWERED).build());
+    }
+}

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockFluidConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockFluidConfig.java
@@ -54,7 +54,7 @@ public abstract class BlockFluidConfig extends BlockConfig {
     public void onModelRegistryLoad(ModelRegistryEvent event) {
         // Handle registration for fluid rendering
         BlockFluidClassic blockInstance = getBlockInstance();
-        Item fluid = Item.getItemFromBlock(blockInstance);
+        Item fluid = getItemInstance();
 
         ModelBakery.registerItemVariants(fluid, fluidLocation);
 

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockItemConfigReference.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/BlockItemConfigReference.java
@@ -28,6 +28,6 @@ public class BlockItemConfigReference implements IObjectReference<Item> {
                         blockConfigClass.getName());
             }
         }
-        return blockConfig != null ? Item.getItemFromBlock(blockConfig.getBlockInstance()) : null;
+        return blockConfig != null ? blockConfig.getItemInstance() : null;
     }
 }

--- a/src/main/java/org/cyclops/cyclopscore/item/ItemDoorMetadata.java
+++ b/src/main/java/org/cyclops/cyclopscore/item/ItemDoorMetadata.java
@@ -1,0 +1,76 @@
+package org.cyclops.cyclopscore.item;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.cyclops.cyclopscore.block.IBlockRarityProvider;
+import org.cyclops.cyclopscore.config.configurable.ConfigurableBlockDoor;
+import org.cyclops.cyclopscore.helper.L10NHelpers;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.EnumRarity;
+import net.minecraft.item.ItemDoor;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+/**
+ * A hybrid of {@link org.cyclops.cyclopscore.item.ItemBlockMetadata} and {@link net.minecraft.item.ItemDoor}.
+ * @author josephcsible
+ *
+ */
+public class ItemDoorMetadata extends ItemDoor {
+    protected InformationProviderComponent informationProvider;
+    protected IBlockRarityProvider rarityProvider = null;
+
+    protected final ConfigurableBlockDoor block;
+    public ItemDoorMetadata(Block block) {
+        super(block);
+        this.block = (ConfigurableBlockDoor) block;
+        this.block.item = this;
+        informationProvider = new InformationProviderComponent(block);
+        if(block instanceof IBlockRarityProvider) {
+            rarityProvider = (IBlockRarityProvider) block;
+        }
+    }
+
+    @Override
+    public String getUnlocalizedName(ItemStack stack)
+    {
+        return block.getUnlocalizedName();
+    }
+
+    @Override
+    public String getUnlocalizedName()
+    {
+        return block.getUnlocalizedName();
+    }
+
+    @Override
+    public CreativeTabs getCreativeTab()
+    {
+        return block.getCreativeTabToDisplayOn();
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack itemStack, @Nullable World world, List<String> list, ITooltipFlag flag)
+    {
+        super.addInformation(itemStack, world, list, flag);
+        block.addInformation(itemStack, world, list, flag);
+        L10NHelpers.addOptionalInfo(list, getUnlocalizedName());
+        informationProvider.addInformation(itemStack, world, list, flag);
+    }
+
+    @Override
+    public EnumRarity getRarity(ItemStack itemStack) {
+        if(rarityProvider != null) {
+            return rarityProvider.getRarity(itemStack);
+        }
+        return super.getRarity(itemStack);
+    }
+}


### PR DESCRIPTION
Let blocks' items be any Item, not just ItemBlock

Some blocks, such as doors, have custom items that just extend Item instead of
extending ItemBlock. Since we don't need any of ItemBlock's functionality for
anything, switch to using Item in its place.

Break out getItemInstance() so not everything has to use Item.getItemFromBlock()

Add support for doors