### PR TITLE
Actually fix Travis build failing on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - TERM=dumb
 
-before_install: '[ "${TRAVIS_PULL_REQUEST}" = "true" ] || openssl aes-256-cbc -K $encrypted_0c9cfa39ea8e_key -iv $encrypted_0c9cfa39ea8e_iv -in keystore.jks.enc -out keystore.jks -d'
+before_install: '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || openssl aes-256-cbc -K $encrypted_0c9cfa39ea8e_key -iv $encrypted_0c9cfa39ea8e_iv -in keystore.jks.enc -out keystore.jks -d'
 install: ./gradlew setupCIWorkspace -S
 script: ./gradlew build -S
 


### PR DESCRIPTION
Although $TRAVIS_PULL_REQUEST is "false" when it's not a PR, it's the PR
number when it is, not "true". Therefore, we need to test it against "false",
not "true".