### PR TITLE
Revert "Fix netty leak, Closes #82"

### DIFF
--- a/src/main/java/org/cyclops/cyclopscore/network/PacketBase.java
+++ b/src/main/java/org/cyclops/cyclopscore/network/PacketBase.java
@@ -51,7 +51,6 @@ public abstract class PacketBase implements IMessage {
 	@Override
 	public void fromBytes(ByteBuf source) {
 		decode(new ExtendedBuffer(source));
-		source.release();
 	}
 
 	@Override


### PR DESCRIPTION
This is Forge's duty to release (MinecraftForge/MinecraftForge#4510), not
ours. Fixes CyclopsMC/IntegratedDynamics#364 and
fixes CyclopsMC/EverlastingAbilities#59.

This reverts commit 6131a3f95d1c3197dbcba79a579d3a8725a8bb10.