### PR TITLE
Fix AbstractMethodError crash in SRG name envrionment

### DIFF
--- a/src/main/java/org/cyclops/cyclopscore/client/gui/container/ContainerScreenExtended.java
+++ b/src/main/java/org/cyclops/cyclopscore/client/gui/container/ContainerScreenExtended.java
@@ -150,7 +150,7 @@ public abstract class ContainerScreenExtended<T extends ContainerExtended> exten
     }
 
     @Override
-    public ContainerType<?> getType() {
-        return getContainer().getType();
+    public ContainerType<?> getContainerType() {
+        return getContainer().getContainerType();
     }
 }

--- a/src/main/java/org/cyclops/cyclopscore/inventory/IValueNotifiable.java
+++ b/src/main/java/org/cyclops/cyclopscore/inventory/IValueNotifiable.java
@@ -13,7 +13,7 @@ public interface IValueNotifiable {
     /**
      * @return The container type.
      */
-    public ContainerType<?> getType();
+    public ContainerType<?> getContainerType();
 
     /**
      * Called by the server if the value has changed.

--- a/src/main/java/org/cyclops/cyclopscore/inventory/container/ContainerExtended.java
+++ b/src/main/java/org/cyclops/cyclopscore/inventory/container/ContainerExtended.java
@@ -26,6 +26,7 @@ import org.cyclops.cyclopscore.inventory.slot.SlotArmor;
 import org.cyclops.cyclopscore.inventory.slot.SlotExtended;
 import org.cyclops.cyclopscore.network.packet.ValueNotifyPacket;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -137,6 +138,12 @@ public abstract class ContainerExtended extends Container implements IContainerB
 
     public static void setSlotPosY(Slot slot, int newValue) {
         setSlotPos(slot, "field_75221_f", newValue);
+    }
+
+    @Override
+    @Nonnull
+    public ContainerType<?> getContainerType() {
+        return super.getType();
     }
 
     @Override
@@ -492,9 +499,11 @@ public abstract class ContainerExtended extends Container implements IContainerB
     public void setValue(int valueId, CompoundNBT value) {
         if (!values.containsKey(valueId) || !values.get(valueId).equals(value)) {
             if (!player.getEntityWorld().isRemote()) { // server -> client
-                CyclopsCore._instance.getPacketHandler().sendToPlayer(new ValueNotifyPacket(getType(), valueId, value), (ServerPlayerEntity) player);
+                CyclopsCore._instance.getPacketHandler().sendToPlayer(new ValueNotifyPacket(
+                    getContainerType(), valueId, value), (ServerPlayerEntity) player);
             } else { // client -> server
-                CyclopsCore._instance.getPacketHandler().sendToServer(new ValueNotifyPacket(getType(), valueId, value));
+                CyclopsCore._instance.getPacketHandler().sendToServer(new ValueNotifyPacket(
+                    getContainerType(), valueId, value));
             }
             values.put(valueId, value);
         }

--- a/src/main/java/org/cyclops/cyclopscore/network/packet/ValueNotifyPacket.java
+++ b/src/main/java/org/cyclops/cyclopscore/network/packet/ValueNotifyPacket.java
@@ -43,7 +43,7 @@ public class ValueNotifyPacket extends PacketCodec {
 	}
 
 	protected boolean isContainerValid(IValueNotifiable container) {
-    	return container.getType().getRegistryName().toString().equals(containerType);
+    	return container.getContainerType().getRegistryName().toString().equals(containerType);
 	}
 
 	@Override


### PR DESCRIPTION
The crash can be reproduced by interacting with any container that extends `ContainerExtended` in non-development envrionment.

This PR renames `IValueNotifiable`'s `getType` to `getContainerType` and implement the said method in `ContainerExtended` class.

Previously, `ContainerExtended` implements the `IValueNotifiable` interface by extending vanilla class Container, which has a method called `getType`. However, after `reobfuscation`, the `getType` method from Container class gets reobfuscated to some other name, causing `ContainerExtended` to no longer properly implement `IValueNotifiable`, and leading to AbstractMethodError during runtime.