### PR TITLE
Port to 1.16.3

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 mod_version=1.11.1
-minecraft_version=1.16.5
-forge_version=36.0.14
+minecraft_version=1.16.3
+forge_version=34.1.42
 mcp_mappings_channel=snapshot
 mcp_mappings_version=20201028-1.16.3
 release_type=release

--- a/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/FoliagePlacerConfig.java
+++ b/src/main/java/org/cyclops/cyclopscore/config/extendedconfig/FoliagePlacerConfig.java
@@ -8,6 +8,9 @@ import net.minecraftforge.registries.IForgeRegistry;
 import org.cyclops.cyclopscore.config.ConfigurableType;
 import org.cyclops.cyclopscore.init.ModBase;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
@@ -19,9 +22,19 @@ public class FoliagePlacerConfig<T extends FoliagePlacer> extends ExtendedConfig
 
     public FoliagePlacerConfig(ModBase mod, String namedId, Function<FoliagePlacerConfig<T>, Codec<T>> codec) {
         super(mod, namedId, (eConfig) -> {
-            FoliagePlacerType<T> type = new FoliagePlacerType<>(codec.apply(eConfig));
-            type.setRegistryName(mod.getModId(), namedId);
-            return type;
+            try {
+                Constructor<FoliagePlacerType> constructor = FoliagePlacerType.class.getDeclaredConstructor(Codec.class);
+                constructor.setAccessible(true);
+                FoliagePlacerType fpt = constructor.newInstance(codec.apply(eConfig));
+
+                FoliagePlacerType<T> type = fpt;
+                type.setRegistryName(mod.getModId(), namedId);
+
+                return type;
+            }catch(Exception ex){
+                System.out.println("Error reflecting: "+ex.getMessage());
+            }
+            return null;
         });
     }
 

--- a/src/main/java/org/cyclops/cyclopscore/metadata/RegistryExportableItemTranslationKeys.java
+++ b/src/main/java/org/cyclops/cyclopscore/metadata/RegistryExportableItemTranslationKeys.java
@@ -22,6 +22,9 @@ public class RegistryExportableItemTranslationKeys implements IRegistryExportabl
             Item value = ForgeRegistries.ITEMS.getValue(key);
             ItemStack itemStack = new ItemStack(value);
             String translationKey = itemStack.getTranslationKey();
+            if (!translationKey.endsWith(".name")) {
+                translationKey += ".name";
+            }
 
             JsonObject object = new JsonObject();
             object.addProperty("translationKey", translationKey);


### PR DESCRIPTION
Makes the core compatible with 1.16.3 which many people still use due to the amount of mods currently compatible with that version. ColossalChests works on it's own without edits, Cyclops Core just needed an access change and it was good to go. I'd recommend sticking this in a 1.16.3 branch to avoid messing up master.