### PR TITLE
Use HashMap for local RegistryKey<World> cache

### DIFF
--- a/src/main/java/org/cyclops/cyclopscore/datastructure/DimPos.java
+++ b/src/main/java/org/cyclops/cyclopscore/datastructure/DimPos.java
@@ -60,7 +60,7 @@ public class DimPos implements Comparable<DimPos> {
             if (MinecraftHelpers.isClientSideThread()) {
                 final ClientWorld world = Minecraft.getInstance().world;
 
-                if (world.getDimensionKey().getLocation().toString().equals(this.getWorld())) {
+                if (world != null && world.getDimensionKey().getLocation().toString().equals(this.getWorld())) {
                     this.worldReference = new WeakReference<>(world);
                     return this.worldReference.get();
                 }


### PR DESCRIPTION
Crudely fixes #155 

This is an assumption on that `RegistryKey.UNIVERSAL_KEY_MAP` is never cleared since it is private, and nothing inside class clear it.

![idea64_nswHQJmaO2](https://user-images.githubusercontent.com/6339511/115716628-903f5b00-a3a3-11eb-8d0c-dcad5616322c.png)

![Xming_YhzulVmsUo](https://user-images.githubusercontent.com/6339511/115716142-13ac7c80-a3a3-11eb-8677-054f32d4a928.png)
