### PR TITLE
Add AlmostUnified compat

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,7 @@ neoforge_loader_version_range=[4,)
 neoforge_update_json_url=https://raw.githubusercontent.com/CyclopsMC/Versions/master/neoforge_update/cyclops-core.json
 # Dependencies
 neoforge_curios_version=7.3.4+1.20.4
+neoforge_almostunified_version=1.21.1-1.3.0
 
 # Forge
 forge_version=52.0.3

--- a/loader-common/src/main/java/org/cyclops/cyclopscore/Reference.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/Reference.java
@@ -17,6 +17,7 @@ public final class Reference {
     public static final String MOD_CURIOS = "curios";
     public static final String MOD_JEI = "jei";
     public static final String MOD_COMMONCAPABILITIES = "commoncapabilities";
+    public static final String MOD_ALMOSTUNIFIED = "almostunified";
 
     // Paths
     public static final String TEXTURE_PATH_PARTICLES = "textures/particle/";

--- a/loader-neoforge/build.gradle
+++ b/loader-neoforge/build.gradle
@@ -35,6 +35,10 @@ repositories {
         name "Curios"
         url "https://maven.theillusivec4.top/"
     }
+    maven {
+        name "BlameJared"
+        url "https://maven.blamejared.com"
+    }
 }
 
 dependencies {
@@ -42,6 +46,8 @@ dependencies {
 
     //runtimeOnly fg.deobf("top.theillusivec4.curios:curios-neoforge:${curios_version}") // https://maven.theillusivec4.top/top/theillusivec4/curios/curios-neoforge/
     compileOnly "top.theillusivec4.curios:curios-neoforge:${neoforge_curios_version}:api"
+    //runtimeOnly "com.almostreliable.mods:almostunified-neoforge:${neoforge_almostunified_version}" // https://maven.blamejared.com/com/almostreliable/mods/almostunified-neoforge/
+    compileOnly "com.almostreliable.mods:almostunified-neoforge:${neoforge_almostunified_version}:api"
 
     // Project lombok
     compileOnly 'org.projectlombok:lombok:1.18.30'

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/CyclopsCore.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/CyclopsCore.java
@@ -48,6 +48,7 @@ import org.cyclops.cyclopscore.metadata.IRegistryExportableRegistry;
 import org.cyclops.cyclopscore.metadata.RegistryExportableRegistry;
 import org.cyclops.cyclopscore.metadata.RegistryExportables;
 import org.cyclops.cyclopscore.modcompat.ModCompatLoader;
+import org.cyclops.cyclopscore.modcompat.almostunified.ModCompatAlmostUnified;
 import org.cyclops.cyclopscore.modcompat.curios.ModCompatCurios;
 import org.cyclops.cyclopscore.network.PacketCodecsNeoForge;
 import org.cyclops.cyclopscore.persist.nbt.NBTClassTypesNeoForge;
@@ -102,6 +103,7 @@ public class CyclopsCore extends ModBaseVersionable<CyclopsCore> {
         ModCompatLoader modCompatLoader = super.constructModCompatLoader();
 
         modCompatLoader.addModCompat(new ModCompatCurios());
+        modCompatLoader.addModCompat(new ModCompatAlmostUnified());
 
         return modCompatLoader;
     }

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/modcompat/almostunified/AlmostUnifiedAdapter.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/modcompat/almostunified/AlmostUnifiedAdapter.java
@@ -1,0 +1,28 @@
+package org.cyclops.cyclopscore.modcompat.almostunified;
+
+import com.almostreliable.unified.api.AlmostUnified;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import org.jetbrains.annotations.Nullable;
+
+public class AlmostUnifiedAdapter {
+
+    public static boolean enabled = false;
+
+    @Nullable
+    public static Item getTagTargetItem(TagKey<Item> tag) {
+        if (enabled) {
+            return Adapter.getTagTargetItem(tag);
+        }
+
+        return null;
+    }
+
+    private static final class Adapter {
+
+        @Nullable
+        private static Item getTagTargetItem(TagKey<Item> tag) {
+            return AlmostUnified.INSTANCE.getTagTargetItem(tag);
+        }
+    }
+}

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/modcompat/almostunified/ModCompatAlmostUnified.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/modcompat/almostunified/ModCompatAlmostUnified.java
@@ -1,0 +1,27 @@
+package org.cyclops.cyclopscore.modcompat.almostunified;
+
+import org.cyclops.cyclopscore.Reference;
+import org.cyclops.cyclopscore.modcompat.ICompatInitializer;
+import org.cyclops.cyclopscore.modcompat.IModCompat;
+
+public class ModCompatAlmostUnified implements IModCompat {
+    @Override
+    public String getId() {
+        return Reference.MOD_ALMOSTUNIFIED;
+    }
+
+    @Override
+    public boolean isEnabledDefault() {
+        return true;
+    }
+
+    @Override
+    public String getComment() {
+        return "Recipe unification";
+    }
+
+    @Override
+    public ICompatInitializer createInitializer() {
+        return new ModCompatAlmostUnifiedInitializer();
+    }
+}

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/modcompat/almostunified/ModCompatAlmostUnifiedInitializer.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/modcompat/almostunified/ModCompatAlmostUnifiedInitializer.java
@@ -1,0 +1,10 @@
+package org.cyclops.cyclopscore.modcompat.almostunified;
+
+import org.cyclops.cyclopscore.modcompat.ICompatInitializer;
+
+public class ModCompatAlmostUnifiedInitializer implements ICompatInitializer {
+    @Override
+    public void initialize() {
+        AlmostUnifiedAdapter.enabled = true;
+    }
+}

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/recipe/ItemStackFromIngredient.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/recipe/ItemStackFromIngredient.java
@@ -3,9 +3,14 @@ package org.cyclops.cyclopscore.recipe;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import org.cyclops.cyclopscore.modcompat.almostunified.AlmostUnifiedAdapter;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -51,6 +56,12 @@ public class ItemStackFromIngredient {
     public ItemStack getFirstItemStack() {
         if (firstItemStack != null) {
             return firstItemStack;
+        }
+
+        TagKey<Item> tagKey = TagKey.create(Registries.ITEM, ResourceLocation.parse(tag));
+        Item almostUnifiedTarget = AlmostUnifiedAdapter.getTagTargetItem(tagKey);
+        if (almostUnifiedTarget != null) {
+            return new ItemStack(almostUnifiedTarget, count);
         }
 
         // Obtain all stacks for the given tag


### PR DESCRIPTION
This pull request introduces integration for [Almost Unified](https://github.com/AlmostReliable/almostunified).

I tried integrating it with the existing `ModCompat` system. Feel free to remove it and just make use of the `AlmostUnifiedAdapter`. It already guards against class access if the mod is not loaded via the nested static class. The implementation makes Almost Unified a soft dependency.

The current use case is the `ItemStackFromIngredient` class, which will make use of the adapter to resolve the stored tag to the preferred item. I would suggest not caching the resolved stack in the class in case the Almost Unified config changes (the mod is fully reloadable). The performance impact should be negligible because it's a simple map lookup on our side.

I tested the implementation with Integrated Dynamics via Maven local. The Mechanical Squeezer makes use of the `ItemStackFromIngredient` class for its outputs. I was able to fully reload config changes and see the expected results in the recipe. The mod still works normally if Almost Unified is not present.
Because Almost Unified takes priority over its own mod priority system, it may be a good idea to mention this in the config option right here:  https://github.com/CyclopsMC/IntegratedDynamics/blob/master-1.21-lts/src/main/java/org/cyclops/integrateddynamics/GeneralConfig.java#L127-L128

If Almost Unified can't provide the preferred item for the tag, the implementation will fall back to the previous behavior. This integration simplifies modpack work because it fetches the mod priorities from a single point of truth. To fully support all features of Almost Unified, I may add a pull request to Integrated Dynamics too.