### PR TITLE
perf: check Class#isInstance before casting

### DIFF
--- a/loader-common/src/main/java/org/cyclops/cyclopscore/helper/BlockEntityHelpersCommon.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/helper/BlockEntityHelpersCommon.java
@@ -32,9 +32,9 @@ public class BlockEntityHelpersCommon implements IBlockEntityHelpers {
         if (blockEntity == null) {
             return Optional.empty();
         }
-        try {
+        if (targetClazz.isInstance(blockEntity)) {
             return Optional.of(targetClazz.cast(blockEntity));
-        } catch (ClassCastException e) {
+        } else {
             return Optional.empty();
         }
     }


### PR DESCRIPTION
ensures that a ClassCastException won't be generated, as doing so costs a lot
<img width="2379" height="732" alt="image" src="https://github.com/user-attachments/assets/3474a290-e723-4e3d-b432-80a1ed61fc87" />
