### PR TITLE
Fix GUIs not opening when player is forced into a crouching pose

### DIFF
--- a/src/main/java/org/cyclops/cyclopscore/block/IBlockGui.java
+++ b/src/main/java/org/cyclops/cyclopscore/block/IBlockGui.java
@@ -40,8 +40,10 @@ public interface IBlockGui {
     }
 
     public static InteractionResult onBlockActivatedHook(IBlockGui block, IBlockContainerProvider blockContainerProvider, BlockState blockState, Level world, BlockPos blockPos, Player player, InteractionHand hand, BlockHitResult rayTraceResult) {
-        // Drop through if the player is sneaking
-        if (player.isCrouching()) {
+        // Drop through if the player is sneaking.
+        // Note that we can not check isCrouching here, as that is pose-based,
+        // and is also true when the player is forced into a crouching pose by a low ceiling.
+        if (player.isSecondaryUseActive()) {
             return InteractionResult.PASS;
         }
 

--- a/src/main/java/org/cyclops/cyclopscore/event/LecternInfoBookHandler.java
+++ b/src/main/java/org/cyclops/cyclopscore/event/LecternInfoBookHandler.java
@@ -26,7 +26,7 @@ public class LecternInfoBookHandler {
                 && blockState.is(Blocks.LECTERN)
                 && blockEntity instanceof LecternBlockEntity lecternBlockEntity
                 && lecternBlockEntity.getBook().getItem() instanceof ItemGui itemGui) {
-            if (event.getEntity().isCrouching()) {
+            if (event.getEntity().isSecondaryUseActive()) {
                 // Remove book from lectern if sneaking
                 ItemStackHelpers.spawnItemStack(event.getLevel(), event.getPos().relative(blockState.getValue(LecternBlock.FACING)), lecternBlockEntity.getBook().copy());
                 LecternBlock.resetBookState(event.getEntity(), event.getLevel(), event.getPos(), blockState, false);


### PR DESCRIPTION
Fixes CyclopsMC/IntegratedDynamics#1695, where a player wedged between cables (and therefore locked into a crouching pose) could not open the variable store GUI.

### Cause

`IBlockGui.onBlockActivatedHook` dropped through with `InteractionResult.PASS` when `player.isCrouching()`. That method is **pose**-based (`getPose() == Pose.CROUCHING`), and vanilla's `Player#updatePlayerPose` sets that pose in two cases:

```java
else if (this.isShiftKeyDown() || !this.isSleeping() && !this.canPlayerFitWithinBlocksAndEntitiesWhen(Pose.STANDING))
    pose = Pose.CROUCHING;
```

The second case is a player squeezed under a low ceiling, who is crouching without ever holding the sneak key. Every block GUI in the mods building on this (variable store, logic programmer, materializer, proxy, delay, coal generator, squeezers, ...) then refused to open.

### Fix

Check `Entity#isSecondaryUseActive()` instead, which is based on the actual sneak key state (`isShiftKeyDown`, synced from the client via `ServerboundPlayerCommandPacket`) and additionally respects `Item#doesSneakBypassUse`. This also matches what IntegratedDynamics already uses for all of its own sneak checks (`CableHelpers`, `PartTypeBase`, `ItemWrench`, `BlockContainerCabled`, ...).

The same pose-based check was applied in `LecternInfoBookHandler`, where a force-crouched player right-clicking a lectern would eject the info book instead of reading it. It is changed along with it; happy to drop that hunk if you'd rather keep this PR to the GUI hook only.

### Notes

* Only targets `master-1.20-lts` as requested. `master-1.21-lts` and `master-26-lts` carry the identical check in `loader-common/.../IBlockGui.java` and `LecternInfoBookHandler.java`, so they need the same change.
* Not compiled locally: this environment's network policy blocks `maven.minecraftforge.net`, so ForgeGradle cannot resolve for a 1.20.1 build. `Player#isSecondaryUseActive()` is a Forge-patched method that is available on this Forge version — IntegratedDynamics' own `master-1.20-lts` calls it against the same Forge 47.x. CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEu7L41bnZ9GZMvAyEE73j


---
_Generated by [Claude Code](https://claude.ai/code/session_01SEu7L41bnZ9GZMvAyEE73j)_