### PR TITLE
Fix DimPos being persisted under a hardcoded NBT key

### DIFF
--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/persist/nbt/NBTClassTypesNeoForge.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/persist/nbt/NBTClassTypesNeoForge.java
@@ -40,7 +40,7 @@ public class NBTClassTypesNeoForge {
 
             @Override
             public void writePersistedField(String name, DimPos object, ValueOutput tag) {
-                ValueOutput dimPos = tag.child("dim");
+                ValueOutput dimPos = tag.child(name);
                 dimPos.putString("dim", object.getLevel());
                 dimPos.putInt("x", object.getBlockPos().getX());
                 dimPos.putInt("y", object.getBlockPos().getY());
@@ -49,7 +49,10 @@ public class NBTClassTypesNeoForge {
 
             @Override
             public DimPos readPersistedField(String name, ValueInput tag) {
-                ValueInput dimPos = tag.child(name).orElseThrow();
+                ValueInput dimPos = tag.child(name)
+                        // Fallback for data that was written under a hardcoded key by older versions
+                        .or(() -> tag.child("dim"))
+                        .orElseThrow();
                 String dimensionName = dimPos.getString("dim").orElseThrow();
                 ResourceKey<Level> dimensionType = ResourceKey.create(Registries.DIMENSION, Identifier.parse(dimensionName));
                 return DimPos.of(dimensionType, new BlockPos(dimPos.getInt("x").orElseThrow(), dimPos.getInt("y").orElseThrow(), dimPos.getInt("z").orElseThrow()));


### PR DESCRIPTION
### Problem

The `ValueInput`/`ValueOutput` migration left the `DimPos` NBT type in `NBTClassTypesNeoForge` asymmetric — it writes to a hardcoded `"dim"` child but reads a child named after the field:

```java
public void writePersistedField(String name, DimPos object, ValueOutput tag) {
    ValueOutput dimPos = tag.child("dim");   // <- hardcoded
    ...
}

public DimPos readPersistedField(String name, ValueInput tag) {
    ValueInput dimPos = tag.child(name).orElseThrow();   // <- by field name
    ...
}
```

So no persisted `DimPos` ever round-trips; reading always throws. `master-1.21-lts` and earlier are correct (`tag.put(name, dimPos)` / `tag.getCompound(name)`), so this is a regression limited to the `ValueOutput`-based branches. A second consequence: two `DimPos` fields written into the same tag under different names clobber each other.

This is what crashes IntegratedDynamics clients in CyclopsMC/IntegratedDynamics#1703, via `ValueTypeListProxyPositioned`:

```
java.util.NoSuchElementException: No value present
	at java.base/java.util.Optional.orElseThrow(Optional.java:377)
	at NBTClassTypesNeoForge$2.readPersistedField(NBTClassTypesNeoForge.java:52)
	at NBTClassTypesNeoForge$2.readPersistedField(NBTClassTypesNeoForge.java:39)
	at NBTClassType.readNbt(NBTClassType.java:498)
	at ValueTypeListProxyPositioned.readGeneratedFieldsFromNBT(...)
```

`PositionedOperator` and anything else persisting a `DimPos` hit the same thing.

### Changes

* Write to `tag.child(name)` instead of `tag.child("dim")`.
* Reading falls back to the old hardcoded `"dim"` key when the named child is absent, so data already written by affected versions stays readable instead of throwing.

### Testing

`loader-neoforge`'s own build does not resolve here (the `commoncapabilities` API dependency is unreachable from this environment, and it fails identically on a clean checkout), so I type-checked the changed file against the locally built `loader-common` classes plus the patched Minecraft jar, and drove a round-trip through `TagValueOutput`/`TagValueInput`:

Before:
```
serialized keys: [dim]
Exception in thread "main" java.util.NoSuchElementException: No value present
	at NBTClassTypesNeoForge$2.readPersistedField(NBTClassTypesNeoForge.java:52)
```
(the reporter's exact frames)

After:
```
serialized keys: [pos]
read: minecraft:overworld BlockPos{x=1, y=2, z=3}
legacy read: minecraft:overworld BlockPos{x=1, y=2, z=3}
OK
```

where `legacy read` feeds in a tag whose `DimPos` sits under the old `"dim"` key.

### Branch

Affected branches are `master-1.21.8`, `master-1.21.10`, `master-26-lts` and `master-26`. The two `1.21.x` branches look dormant (last commits Nov/Dec 2025), so this targets `master-26-lts` for upmerging — happy to retarget if you want it lower.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoinY4GW1gaXggj3WxDUcF)_