### PR TITLE
Make the scrolling container reach the last row of a multi-column grid

### DIFF
--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/client/gui/container/ContainerScreenScrolling.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/client/gui/container/ContainerScreenScrolling.java
@@ -4,6 +4,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.Slot;
 import org.cyclops.cyclopscore.client.gui.component.WidgetScrollBar;
@@ -62,7 +63,7 @@ public abstract class ContainerScreenScrolling<T extends ScrollingInventoryConta
             this.scrollbar = new WidgetScrollBar(this.leftPos + getScrollX(), this.topPos + getScrollY(), getScrollHeight(),
                     Component.translatable("gui.cyclopscore.scrollbar"), getMenu(),
                     getMenu().getPageSize(), getScrollRegion());
-            this.scrollbar.setTotalRows(getMenu().getFilteredItemCount() / getMenu().getColumns());
+            this.scrollbar.setTotalRows(getTotalRows());
         } else {
             this.scrollbar.setX(this.leftPos + getScrollX());
             this.scrollbar.setY(this.topPos + getScrollY());
@@ -147,8 +148,20 @@ public abstract class ContainerScreenScrolling<T extends ScrollingInventoryConta
 
     protected void updateSearch(String searchString) {
         getMenu().updateFilter(searchString);
-        this.scrollbar.setTotalRows(getMenu().getFilteredItemCount() / getMenu().getColumns());
+        this.scrollbar.setTotalRows(getTotalRows());
         this.scrollbar.scrollTo(0);
+    }
+
+    /**
+     * The number of rows that the filtered elements occupy.
+     *
+     * This is rounded up, as a last row that is only partially filled
+     * must still be reachable by the scrollbar.
+     *
+     * @return The number of rows.
+     */
+    protected int getTotalRows() {
+        return Mth.ceil((double) getMenu().getFilteredItemCount() / getMenu().getColumns());
     }
 
     public EditBox getSearchField() {

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/inventory/container/ScrollingInventoryContainer.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/inventory/container/ScrollingInventoryContainer.java
@@ -40,7 +40,7 @@ public abstract class ScrollingInventoryContainer<E> extends InventoryContainer 
         this.unfilteredItems = Lists.newArrayList(items);
         this.filteredItems = Lists.newLinkedList();
         this.visibleItems = (List<E>) Arrays.asList(new Object[getPageSize() * getColumns()]);
-        for(int i = 0; i < getPageSize(); i++) {
+        for(int i = 0; i < this.visibleItems.size(); i++) {
             this.visibleItems.set(i, null);
         }
         this.itemSearchPredicate = filterer;
@@ -114,11 +114,11 @@ public abstract class ScrollingInventoryContainer<E> extends InventoryContainer 
 
     /**
      * Check if the given element is visible.
-     * @param row The row the the given element is at.
+     * @param row The index of the given element within the visible elements.
      * @return If it is visible.
      */
     public boolean isElementVisible(int row) {
-        return row < getPageSize() && getVisibleElement(row) != null;
+        return row < getPageSize() * getColumns() && getVisibleElement(row) != null;
     }
 
     /**


### PR DESCRIPTION
`ScrollingInventoryContainer` supports multiple columns — `onScroll` walks `i * getColumns() + j` and `getScrollStepSize()` defaults to `getColumns()` — but two places still assume there is only one.

### The last row is unreachable

`ContainerScreenScrolling` computes the scrollbar's total rows as `filteredItemCount / getColumns()`, in both `init` and `updateSearch`. That truncates, so `WidgetScrollBar#getScrollStep` (`totalRows - visibleRows`) comes out one short and the last, partially filled row can never be scrolled to.

Measured live in a dev client, on a 9-column grid of 985 elements with 6 visible rows, by setting the scrollbar to each value and scrolling fully to the bottom:

| `totalRows` | last row at full scroll | highest reachable element |
| --- | --- | --- |
| `985 / 9` = **109** (today) | 9 cells — a *full* row | index **980** |
| `ceil(985 / 9)` = **110** (this PR) | 4 cells | past index 984 |

The final element is index 984, so **981–984 are unreachable**: the scrollbar is already at the bottom and they never appear.

Rounded up now, in one `getTotalRows()` both call sites share, so a subclass that wants different behaviour has a single place to override.

### `isElementVisible` returns false past the first row

```java
public boolean isElementVisible(int row) {
    return row < getPageSize() && getVisibleElement(row) != null;
}
```

`getPageSize()` is the number of **rows**, while the parameter indexes into the visible elements, which number rows × columns. So for a grid this returns false for everything after the first row, even though `getVisibleElement` returns those elements and `onScroll` fills them in. It now guards against `getPageSize() * getColumns()`; for a single-column container the two are identical, so nothing changes for existing users.

### A cosmetic third one

The constructor null-filled only the first `getPageSize()` entries of a list that is rows × columns long. Harmless, since `Arrays.asList(new Object[n])` is already all-null, but it read as if the rest were left uninitialized.

### How this came up

Building a 9 × 6 recipe grid on `ScrollingInventoryContainer` in IntegratedCrafting (CyclopsMC/IntegratedCrafting#221). Both were worked around locally there; that workaround can go once a release carries this.

### Testing

`./gradlew :loader-neoforge:compileJava` passes. Behaviour verified in a dev client through the IntegratedCrafting grid, as measured above: with the fix, scrolling fully down lands on a last row holding exactly the 4 remaining elements (985 % 9 = 4), and every cell renders across the whole scroll range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9xTc8kXNRDppvXktL24aR
