### PR TITLE
Fix ItemStack hashing and classified ingredient lookups

### DIFF
--- a/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
@@ -115,11 +115,36 @@ public abstract class ItemStackHelpersCommon implements IItemStackHelpers {
         // into a scan doing full component comparisons. This is what made large storage
         // networks scale quadratically. The exclusion dates from NBT tags, which were
         // expensive to hash; component maps are not.
-        // Mirrors ItemStack.hashItemAndComponents, which vanilla uses for the same purpose.
-        result = 37 * result + stack.getComponents().hashCode();
+        //
+        // Only stacks carrying a patch need it. A component map hashes its prototype alongside its
+        // patch, and the prototype is the item's defaults, which the item hashed above already
+        // stands for. Hashing it again distinguishes nothing, and it is the dominant cost for the
+        // plain stacks that most of a storage network consists of.
+        //
+        // This stays consistent with equality because the patch is kept sanitized: setting a
+        // component to its default removes it from the patch rather than storing it, so two stacks
+        // of one item have equal components exactly when they have equal patches.
+        if (hasComponentPatch(stack)) {
+            result = 37 * result + stack.getComponents().hashCode();
+        }
         // Not factoring in capability compatibility. Doing so would require either reflection (slow)
         // or an access transformer, it's highly unlikely that it'd be the only difference between
         // many ItemStacks in practice, and occasional hash code collisions are okay.
         return result;
+    }
+
+    /**
+     * If the given stack carries data components that differ from its item's defaults.
+     *
+     * Only those have to take part in {@link #getItemStackHashCode(ItemStack)}.
+     *
+     * @param stack A non-empty stack.
+     * @return If the stack has a non-empty component patch.
+     */
+    protected boolean hasComponentPatch(ItemStack stack) {
+        // Vanilla exposes the patch only by building one. That costs nothing for the stacks this
+        // is here to catch, as an empty patch yields the shared empty instance. Loaders that can
+        // answer without building anything should override this.
+        return !stack.getComponentsPatch().isEmpty();
     }
 }

--- a/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
@@ -109,21 +109,6 @@ public abstract class ItemStackHelpersCommon implements IItemStackHelpers {
         int result = 1;
         result = 37 * result + stack.getCount();
         result = 37 * result + stack.getItem().hashCode();
-        // Data components have to be part of the hash, because equality compares them.
-        // Leaving them out makes every stack of the same item hash alike, so hash-based
-        // ingredient collections collapse into one bucket per item and every lookup turns
-        // into a scan doing full component comparisons. This is what made large storage
-        // networks scale quadratically. The exclusion dates from NBT tags, which were
-        // expensive to hash; component maps are not.
-        //
-        // Only stacks carrying a patch need it. A component map hashes its prototype alongside its
-        // patch, and the prototype is the item's defaults, which the item hashed above already
-        // stands for. Hashing it again distinguishes nothing, and it is the dominant cost for the
-        // plain stacks that most of a storage network consists of.
-        //
-        // This stays consistent with equality because the patch is kept sanitized: setting a
-        // component to its default removes it from the patch rather than storing it, so two stacks
-        // of one item have equal components exactly when they have equal patches.
         if (hasComponentPatch(stack)) {
             result = 37 * result + stack.getComponents().hashCode();
         }
@@ -142,9 +127,6 @@ public abstract class ItemStackHelpersCommon implements IItemStackHelpers {
      * @return If the stack has a non-empty component patch.
      */
     protected boolean hasComponentPatch(ItemStack stack) {
-        // Vanilla exposes the patch only by building one. That costs nothing for the stacks this
-        // is here to catch, as an empty patch yields the shared empty instance. Loaders that can
-        // answer without building anything should override this.
         return !stack.getComponentsPatch().isEmpty();
     }
 }

--- a/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
@@ -109,9 +109,14 @@ public abstract class ItemStackHelpersCommon implements IItemStackHelpers {
         int result = 1;
         result = 37 * result + stack.getCount();
         result = 37 * result + stack.getItem().hashCode();
-        // Tags can be very large, and expensive to calculate, which is not needed for hashCodes.
-        // CompoundTag tagCompound = stack.getTag();
-        // result = 37 * result + (tagCompound != null ? tagCompound.hashCode() : 0);
+        // Data components have to be part of the hash, because equality compares them.
+        // Leaving them out makes every stack of the same item hash alike, so hash-based
+        // ingredient collections collapse into one bucket per item and every lookup turns
+        // into a scan doing full component comparisons. This is what made large storage
+        // networks scale quadratically. The exclusion dates from NBT tags, which were
+        // expensive to hash; component maps are not.
+        // Mirrors ItemStack.hashItemAndComponents, which vanilla uses for the same purpose.
+        result = 37 * result + stack.getComponents().hashCode();
         // Not factoring in capability compatibility. Doing so would require either reflection (slow)
         // or an access transformer, it's highly unlikely that it'd be the only difference between
         // many ItemStacks in practice, and occasional hash code collisions are okay.

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersNeoForge.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersNeoForge.java
@@ -13,7 +13,6 @@ public class ItemStackHelpersNeoForge extends ItemStackHelpersCommon {
 
     @Override
     protected boolean hasComponentPatch(ItemStack stack) {
-        // Answers without building the patch instance that the common implementation needs
         return !stack.isComponentsPatchEmpty();
     }
 }

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersNeoForge.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersNeoForge.java
@@ -10,4 +10,10 @@ public class ItemStackHelpersNeoForge extends ItemStackHelpersCommon {
     public ItemStack getCraftingRemainingItem(ItemStack itemStack) {
         return itemStack.getCraftingRemainder().create();
     }
+
+    @Override
+    protected boolean hasComponentPatch(ItemStack stack) {
+        // Answers without building the patch instance that the common implementation needs
+        return !stack.isComponentsPatchEmpty();
+    }
 }

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientCollectionSingleClassified.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientCollectionSingleClassified.java
@@ -176,13 +176,17 @@ public class IngredientCollectionSingleClassified<T, M, C, L extends IIngredient
         }
         if (appliesToClassifier(matchCondition)) {
             IIngredientCollectionMutable<T, M> collection = this.classifiedCollections.get(getClassifier(instance));
-            if (collection != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return collection.size();
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return collection.count(instance, subMatchCondition);
-                }
+            if (collection == null) {
+                // The match condition requires the classifier to be equal, so an absent classifier
+                // means nothing can match. Falling through to the unclassified path here would scan
+                // every instance for a result that is known to be zero.
+                return 0;
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return collection.size();
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return collection.count(instance, subMatchCondition);
             }
         }
         return super.count(instance, matchCondition);

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapSingleClassified.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapSingleClassified.java
@@ -8,6 +8,7 @@ import org.cyclops.commoncapabilities.api.ingredient.IngredientComponentCategory
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -121,13 +122,17 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
     public boolean containsKey(T instance, M matchCondition) {
         if (appliesToClassifier(matchCondition)) {
             IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(getClassifier(instance));
-            if (map != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return true;
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return map.containsKey(instance, subMatchCondition);
-                }
+            if (map == null) {
+                // The match condition requires the classifier to be equal, so an absent classifier
+                // means nothing can match. Falling through to the unclassified path here would scan
+                // every key for a result that is known to be empty.
+                return false;
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return true;
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return map.containsKey(instance, subMatchCondition);
             }
         }
         return super.containsKey(instance, matchCondition);
@@ -137,13 +142,14 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
     public int countKey(T instance, M matchCondition) {
         if (appliesToClassifier(matchCondition)) {
             IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(getClassifier(instance));
-            if (map != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return map.size();
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return map.countKey(instance, subMatchCondition);
-                }
+            if (map == null) {
+                return 0;
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return map.size();
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return map.countKey(instance, subMatchCondition);
             }
         }
         return super.countKey(instance, matchCondition);
@@ -192,13 +198,14 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
     public Collection<V> getAll(T key, M matchCondition) {
         if (appliesToClassifier(matchCondition)) {
             IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(getClassifier(key));
-            if (map != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return map.values();
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return map.getAll(key, subMatchCondition);
-                }
+            if (map == null) {
+                return Collections.emptyList();
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return map.values();
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return map.getAll(key, subMatchCondition);
             }
         }
         return super.getAll(key, matchCondition);
@@ -208,13 +215,14 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
     public IngredientSet<T, M> keySet(T key, M matchCondition) {
         if (appliesToClassifier(matchCondition)) {
             IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(getClassifier(key));
-            if (map != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return map.keySet();
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return map.keySet(key, subMatchCondition);
-                }
+            if (map == null) {
+                return new IngredientHashSet<>(getComponent());
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return map.keySet();
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return map.keySet(key, subMatchCondition);
             }
         }
         return super.keySet(key, matchCondition);

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
@@ -1,0 +1,109 @@
+package org.cyclops.cyclopscore.helper;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import org.cyclops.cyclopscore.inventory.ItemDummy;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Unit tests for the ItemStack hash code of {@link ItemStackHelpersCommon}.
+ *
+ * The hash has to take data components into account. Ingredient collections key on it, and a
+ * component-blind hash puts every stack of the same item in one bucket, which turns their
+ * lookups into scans over full component comparisons.
+ *
+ * @author rubensworks
+ */
+public class TestItemStackHelpersHashCode {
+
+    static {
+        ((MappedRegistry) BuiltInRegistries.ITEM).unfreeze(true);
+    }
+
+    private static final Item ITEM1 = new ItemDummy();
+    private static final Item ITEM2 = new ItemDummy();
+
+    static {
+        ((Holder.Reference<Item>) ITEM1.builtInRegistryHolder()).bindComponents(DataComponentMap.EMPTY);
+        ((Holder.Reference<Item>) ITEM2.builtInRegistryHolder()).bindComponents(DataComponentMap.EMPTY);
+    }
+
+    private static int hash(ItemStack stack) {
+        return new ItemStackHelpersCommon() {}.getItemStackHashCode(stack);
+    }
+
+    private static ItemStack named(Item item, int count, String name) {
+        ItemStack stack = new ItemStack(item, count);
+        stack.set(DataComponents.CUSTOM_NAME, Component.literal(name));
+        return stack;
+    }
+
+    @Test
+    public void testEqualStacksHashEqual() {
+        assertThat(hash(new ItemStack(ITEM1)), is(hash(new ItemStack(ITEM1))));
+        assertThat(hash(new ItemStack(ITEM1, 7)), is(hash(new ItemStack(ITEM1, 7))));
+        assertThat(hash(named(ITEM1, 3, "a")), is(hash(named(ITEM1, 3, "a"))));
+        assertThat(hash(ItemStack.EMPTY), is(hash(ItemStack.EMPTY)));
+    }
+
+    @Test
+    public void testDifferentItemsHashDifferently() {
+        assertThat(hash(new ItemStack(ITEM1)), is(not(hash(new ItemStack(ITEM2)))));
+    }
+
+    @Test
+    public void testDifferentCountsHashDifferently() {
+        assertThat(hash(new ItemStack(ITEM1, 1)), is(not(hash(new ItemStack(ITEM1, 2)))));
+    }
+
+    /**
+     * The regression this guards: stacks of one item differing only by components used to share a hash.
+     */
+    @Test
+    public void testComponentsAffectHash() {
+        assertThat(hash(named(ITEM1, 1, "a")), is(not(hash(named(ITEM1, 1, "b")))));
+        assertThat(hash(new ItemStack(ITEM1)), is(not(hash(named(ITEM1, 1, "a")))));
+    }
+
+    /**
+     * A single differing hash could be luck. Over a sample of same-item stacks the hash has to
+     * spread, or hash-based collections degrade to linear scans.
+     */
+    @Test
+    public void testComponentVariantsSpreadOverManyBuckets() {
+        int samples = 1000;
+        Set<Integer> hashes = new HashSet<>();
+        for (int i = 0; i < samples; i++) {
+            hashes.add(hash(named(ITEM1, 1, "variant " + i)));
+        }
+        assertThat("Component variants of one item have to produce distinct hashes",
+                hashes.size() > samples * 0.99, is(true));
+    }
+
+    /**
+     * The hash may never distinguish two stacks that count as equal, or lookups miss.
+     */
+    @Test
+    public void testHashIsConsistentWithComponentEquality() {
+        for (int i = 0; i < 100; i++) {
+            ItemStack a = named(ITEM1, 1 + (i % 5), "variant " + i);
+            ItemStack b = named(ITEM1, 1 + (i % 5), "variant " + i);
+            assertThat(ItemStack.isSameItemSameComponents(a, b), is(true));
+            assertThat(a.getCount(), is(b.getCount()));
+            assertThat(hash(a), is(hash(b)));
+        }
+    }
+}

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
@@ -41,8 +41,10 @@ public class TestItemStackHelpersHashCode {
         ((Holder.Reference<Item>) ITEM2.builtInRegistryHolder()).bindComponents(DataComponentMap.EMPTY);
     }
 
+    private static final IItemStackHelpers HELPERS = new ItemStackHelpersNeoForge();
+
     private static int hash(ItemStack stack) {
-        return new ItemStackHelpersCommon() {}.getItemStackHashCode(stack);
+        return HELPERS.getItemStackHashCode(stack);
     }
 
     private static ItemStack named(Item item, int count, String name) {

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
@@ -96,6 +96,32 @@ public class TestItemStackHelpersHashCode {
     }
 
     /**
+     * Stacks carrying no component patch skip the component hash, so this pins that they still
+     * spread over items and counts, and still agree with equality.
+     */
+    @Test
+    public void testPlainStacksSpreadOverItemsAndCounts() {
+        assertThat(hash(new ItemStack(ITEM1, 1)), is(not(hash(new ItemStack(ITEM2, 1)))));
+        assertThat(hash(new ItemStack(ITEM1, 1)), is(not(hash(new ItemStack(ITEM1, 2)))));
+        assertThat(hash(new ItemStack(ITEM1, 5)), is(hash(new ItemStack(ITEM1, 5))));
+    }
+
+    /**
+     * A stack whose only component is set back to its default carries no patch any more, so it is
+     * equal to the plain stack and has to hash like one.
+     */
+    @Test
+    public void testComponentSetBackToDefaultHashesAsPlain() {
+        ItemStack plain = new ItemStack(ITEM1);
+        ItemStack restored = new ItemStack(ITEM1);
+        restored.set(DataComponents.CUSTOM_NAME, Component.literal("a"));
+        assertThat(hash(restored), is(not(hash(plain))));
+        restored.set(DataComponents.CUSTOM_NAME, null);
+        assertThat(ItemStack.isSameItemSameComponents(plain, restored), is(true));
+        assertThat(hash(restored), is(hash(plain)));
+    }
+
+    /**
      * The hash may never distinguish two stacks that count as equal, or lookups miss.
      */
     @Test

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestSingleClassifiedAbsentClassifier.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestSingleClassifiedAbsentClassifier.java
@@ -1,0 +1,191 @@
+package org.cyclops.cyclopscore.ingredient.collection;
+
+import org.cyclops.cyclopscore.ingredient.ComplexStack;
+import org.cyclops.cyclopscore.ingredient.IngredientComponentStubs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Queries on a single-classified collection whose classifier holds nothing.
+ *
+ * A match condition that covers the category type can only match instances sharing the query's
+ * classifier, so an absent classifier means an empty result. These lookups must say so directly
+ * rather than falling back on a scan over every classifier, which is both slower and grows with
+ * the size of the whole collection instead of with the size of one classifier.
+ *
+ * @author rubensworks
+ */
+public class TestSingleClassifiedAbsentClassifier {
+
+    private static final int GROUP = ComplexStack.Match.GROUP;
+    private static final int GROUP_META = ComplexStack.Match.GROUP | ComplexStack.Match.META;
+
+    private static final ComplexStack A01 = new ComplexStack(ComplexStack.Group.A, 0, 1, null);
+    private static final ComplexStack A12 = new ComplexStack(ComplexStack.Group.A, 1, 2, null);
+    private static final ComplexStack B01 = new ComplexStack(ComplexStack.Group.B, 0, 1, null);
+    /**
+     * Nothing of this group is ever added.
+     */
+    private static final ComplexStack C01 = new ComplexStack(ComplexStack.Group.C, 0, 1, null);
+
+    /**
+     * Counts every time an inner collection is asked to iterate, so that a fallback scan over all
+     * classifiers becomes visible rather than only slow.
+     */
+    private AtomicInteger innerIterations;
+
+    private IngredientCollectionSingleClassified<ComplexStack, Integer, ?, IIngredientCollectionMutable<ComplexStack, Integer>> collection;
+    private IngredientMapSingleClassified<ComplexStack, Integer, String, ?> map;
+
+    @BeforeEach
+    public void before() {
+        this.innerIterations = new AtomicInteger();
+
+        this.collection = new IngredientCollectionSingleClassified<>(IngredientComponentStubs.COMPLEX,
+                () -> new CountingSet(this.innerIterations),
+                IngredientComponentStubs.COMPLEX.getCategoryTypes().get(0));
+        this.collection.add(A01);
+        this.collection.add(A12);
+        this.collection.add(B01);
+
+        this.map = new IngredientMapSingleClassified<>(IngredientComponentStubs.COMPLEX,
+                () -> new CountingMap(this.innerIterations),
+                IngredientComponentStubs.COMPLEX.getCategoryTypes().get(0));
+        this.map.put(A01, "a01");
+        this.map.put(A12, "a12");
+        this.map.put(B01, "b01");
+
+        this.innerIterations.set(0);
+    }
+
+    @Test
+    public void testCollectionCountAbsentClassifier() {
+        assertThat(collection.count(C01, GROUP), is(0));
+        assertThat(collection.count(C01, GROUP_META), is(0));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testCollectionCountPresentClassifier() {
+        assertThat(collection.count(A01, GROUP), is(2));
+        assertThat(collection.count(B01, GROUP), is(1));
+        assertThat(collection.count(A01, GROUP_META), is(1));
+    }
+
+    @Test
+    public void testMapCountKeyAbsentClassifier() {
+        assertThat(map.countKey(C01, GROUP), is(0));
+        assertThat(map.countKey(C01, GROUP_META), is(0));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testMapCountKeyPresentClassifier() {
+        assertThat(map.countKey(A01, GROUP), is(2));
+        assertThat(map.countKey(B01, GROUP), is(1));
+        assertThat(map.countKey(A01, GROUP_META), is(1));
+    }
+
+    @Test
+    public void testMapContainsKeyAbsentClassifier() {
+        assertThat(map.containsKey(C01, GROUP), is(false));
+        assertThat(map.containsKey(C01, GROUP_META), is(false));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testMapContainsKeyPresentClassifier() {
+        assertThat(map.containsKey(A01, GROUP), is(true));
+        assertThat(map.containsKey(A01, GROUP_META), is(true));
+    }
+
+    @Test
+    public void testMapGetAllAbsentClassifier() {
+        assertThat(map.getAll(C01, GROUP).isEmpty(), is(true));
+        assertThat(map.getAll(C01, GROUP_META).isEmpty(), is(true));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testMapGetAllPresentClassifier() {
+        assertThat(map.getAll(A01, GROUP).size(), is(2));
+        assertThat(map.getAll(B01, GROUP).size(), is(1));
+        assertThat(map.getAll(A01, GROUP_META).size(), is(1));
+    }
+
+    @Test
+    public void testMapKeySetAbsentClassifier() {
+        assertThat(map.keySet(C01, GROUP).isEmpty(), is(true));
+        assertThat(map.keySet(C01, GROUP_META).isEmpty(), is(true));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testMapKeySetPresentClassifier() {
+        assertThat(map.keySet(A01, GROUP).size(), is(2));
+        assertThat(map.keySet(B01, GROUP).size(), is(1));
+        assertThat(map.keySet(A01, GROUP_META).size(), is(1));
+    }
+
+    /**
+     * A match condition that does not cover the category type can not be answered by the
+     * classifier, so it still has to visit the inner collections.
+     */
+    @Test
+    public void testMatchConditionOutsideClassifierStillScans() {
+        assertThat(map.countKey(C01, ComplexStack.Match.META), is(2));
+        assertThat(innerIterations.get() > 0, is(true));
+    }
+
+    private static class CountingSet extends IngredientHashSet<ComplexStack, Integer> {
+
+        private final AtomicInteger counter;
+
+        public CountingSet(AtomicInteger counter) {
+            super(IngredientComponentStubs.COMPLEX);
+            this.counter = counter;
+        }
+
+        @Override
+        public Iterator<ComplexStack> iterator() {
+            this.counter.incrementAndGet();
+            return super.iterator();
+        }
+    }
+
+    private static class CountingMap extends IngredientHashMap<ComplexStack, Integer, String> {
+
+        private final AtomicInteger counter;
+
+        public CountingMap(AtomicInteger counter) {
+            super(IngredientComponentStubs.COMPLEX);
+            this.counter = counter;
+        }
+
+        @Override
+        public Iterator<Map.Entry<ComplexStack, String>> iterator() {
+            this.counter.incrementAndGet();
+            return super.iterator();
+        }
+
+        @Override
+        public IngredientSet<ComplexStack, Integer> keySet() {
+            this.counter.incrementAndGet();
+            return super.keySet();
+        }
+
+        @Override
+        public Collection<String> values() {
+            this.counter.incrementAndGet();
+            return super.values();
+        }
+    }
+}


### PR DESCRIPTION
Three related changes to how ingredient collections find things. The first is the fix; the other two exist because measuring the first exposed them.

## 1. The ItemStack hash ignored data components

`IItemStackHelpers.getItemStackHashCode` hashed only the count and the item, while equality compares components in full. Every stack of the same item therefore hashed alike, so the hash-based ingredient collections collapsed into one bucket per item type and each lookup in such a bucket became a linear scan doing full component comparisons.

The exclusion made sense when stacks carried NBT tags, which were expensive to hash. Component maps are not.

JFR profile of an unmodified 50 000 stack storage terminal open, 3651 server thread samples:

* 65.3% inside `IngredientInstanceWrapper.equals` to `IIngredientMatcher.matchesExactly` to `ItemMatch.areItemStacksEqual` to `DataComparator.compare`
* 61.3% inside treeified `HashMap` buckets (`HashMap$TreeNode.find` 57.1%, `getTreeNode` 43.3%)

Java only treeifies a bucket at eight or more collisions, so a treeified bucket is direct evidence of pathological collisions rather than ordinary hashing cost. `IngredientCollectionPrototypeMap.getPrototype` normalizes the count to 1, which removed the only other varying term and left the hash a function of the item alone.

## 2. Classified lookups scanned everything when the classifier was empty

A single-classified collection partitions instances by a category type. When a query's match condition covers that category, every match has to share the query's classifier, so an absent classifier means an empty result. `contains` and `iterator` already returned one directly. `getAll`, `keySet`, `containsKey`, `countKey` and `count` fell through to the unclassified path, which scans every instance to produce a result already known to be empty.

That made the scan the common case rather than the exception. An IntegratedDynamics storage index keeps one classified map per priority level, so an item lookup visits every level, and every level not holding that item scanned all of its entries. It is why item-only lookups were slow before any of this, and why they got slower still once hashing stopped being nearly free.

This is a pre-existing bug, independent of change 1.

## 3. Plain stacks were hashing their item's default components

A component map hashes its prototype alongside its patch, and the prototype is the item's defaults, which the item already in the hash stands for. Hashing it again distinguishes nothing. For a stack carrying no patch that walk was the entire cost of the hash, and plain stacks are what most of a storage network consists of. Profiling change 1 showed 54.5% of index modification samples inside `DataComponentMap$Builder$SimpleMap.hashCode`, which is exactly that.

This stays consistent with equality because `PatchedDataComponentMap` keeps its patch sanitized: `set` removes an entry equal to the prototype's default rather than storing it, and `applyPatch` and `fromPatch` do the same. Two stacks of one item therefore have equal components exactly when they have equal patches. Vanilla can only report an empty patch by building one, which costs nothing for exactly the stacks this catches, so that is the common implementation and NeoForge overrides it with `isComponentsPatchEmpty`.

## Numbers

IntegratedDynamics index benchmarks, `PERFORMANCE_BENCHMARK_ENABLED=true ./gradlew runGameTestServer`, ms per operation. Medians of six whole runs, except the hash-only column which is one run and is shown only to separate the three changes. The `plain`, `mixed`, `single_item`, `few_items` and `heavy_components` shapes are added in CyclopsMC/IntegratedDynamics#1722.

| benchmark | before | hash only | + classified | + plain | vs before |
|---|---:|---:|---:|---:|---|
| index_lookup_exact | 0.004670 | 0.001614 | 0.001738 | 0.001500 | 3.1x faster |
| index_lookup_item | 0.268168 | 0.820625 | 0.001094 | 0.001097 | 245x faster |
| index_modification | 0.000744 | 0.001789 | 0.001976 | 0.001381 | ~2x slower |
| index_lookup_nonempty_first | 0.000243 | 0.000346 | 0.000252 | 0.000259 | unchanged |
| index_lookup_nonempty_all | 0.012368 | 0.013368 | 0.012332 | 0.012341 | unchanged |
| index_lookup_exact_plain | 0.001227 | 0.002014 | 0.001903 | 0.000954 | 1.3x faster |
| index_lookup_item_plain | 0.231160 | 0.717556 | 0.001175 | 0.001099 | 210x faster |
| index_modification_plain | 0.000540 | 0.001276 | 0.001415 | 0.000507 | 1.1x faster |
| index_lookup_exact_mixed | 0.001618 | | | 0.001190 | 1.4x faster |
| index_lookup_item_mixed | 0.220683 | | | 0.001053 | 210x faster |
| index_modification_mixed | 0.000501 | | | 0.000667 | 1.33x slower |
| index_lookup_exact_single_item | 3.796415 | 0.001340 | 0.001318 | 0.001252 | 3034x faster |
| index_modification_single_item | 3.291132 | 0.001113 | 0.001225 | 0.000688 | 4784x faster |
| index_lookup_item_single_item | 0.432068 | 0.558893 | 0.572138 | 0.582180 | 1.35x slower |
| index_lookup_exact_few_items | 0.070593 | 0.000883 | 0.000845 | 0.000858 | 82x faster |
| index_modification_few_items | 0.156185 | 0.001145 | 0.001146 | 0.000726 | 215x faster |
| index_lookup_exact_heavy_components | 0.003482 | 0.003172 | 0.003255 | 0.002789 | 1.2x faster |
| index_modification_heavy_components | 0.000423 | 0.002611 | 0.002818 | 0.002077 | 4.9x slower |

The `plain` shape is 5000 stacks with no components at all; `mixed` gives one in ten a component, which is closer to a real modpack storage. Both end up faster or unchanged on lookups, and `plain` is unchanged on modification.

### The regressions, stated plainly

**Modification on component-bearing stacks.** 1.33x on the realistic mixed shape, about 2x on the spread shape, 4.9x with a large component payload. In absolute terms that is 166 ns, 640 ns and 1.65 microseconds per operation. Run to run spread on these rows is large, so the factors are not well determined; the direction is. On the plain shape, where a modification hashes no components, it is slightly faster than before.

**Item-only lookup where one item has thousands of variants**, 1.35x. That query has to return every variant, so classification cannot narrow it and each result costs a dearer hash.

Set against them, an item-only lookup on a normal network costs 220 microseconds less, and the collision-heavy shapes are hundreds to thousands of times cheaper. One avoided lookup pays for roughly a thousand modifications.

## Effect on a storage terminal

Terminal open on a loopback dedicated server with IntegratedTerminals, medians of seven runs after a discarded warm-up. Times in ms. Scenario A is a first open, B a re-open.

| case | server before | server after | client before | client after |
|---|---:|---:|---:|---:|
| 1 000 A | 5.1 | 4.4 | 11.5 | 10.0 |
| 10 000 A | 287.7 | 33.1 | 560.5 | 84.0 |
| 10 000 B | 285.4 | 33.0 | 611.5 | 78.0 |
| 50 000 A | 5535.9 | 180.6 | 10482.0 | 567.0 |
| 50 000 B | 5524.3 | 173.5 | 10356.0 | 525.0 |

Scaling stops being superlinear: 50x the stacks costs 31x the server work, against about 1000x before. A 50 000 stack storage where every heavy stack sits on one item used to trip the 60 s single-tick watchdog and now costs 336 ms of server time. Bytes on the wire are unchanged.

## Caller audit

Every caller of `getItemStackHashCode` across CyclopsCore, IntegratedDynamics, IntegratedTerminals and the CommonCapabilities API:

| caller | effect |
|---|---|
| `ItemStackHelpersCommon` | the definition changed here |
| `IItemStackHelpers` | interface declaration only |
| `CraftingHelpersCommon:160`, recipe cache key | its `equals` already used `ItemStack.isSameItemSameComponents`, so the hash was less discriminating than the equality it keyed. Strictly improved. |
| `ValueObjectTypeItemStack:156` (IntegratedDynamics) | `hashCode` for the ItemStack value type, more correct now |
| `IngredientMatcherItemStack.hash` (CommonCapabilities) | the main consumer, and the path every measurement above goes through |

None depend on component-blind hashing for correctness.

## Tests

* `TestItemStackHelpersHashCode`: equal stacks hash equal, different items and counts hash differently, components affect the hash, 1000 component variants of one item produce over 99% distinct hashes, plain stacks still spread over items and counts, a component set back to its default hashes as plain again, and the hash agrees with `ItemStack.isSameItemSameComponents` plus count over 100 samples.
* `TestSingleClassifiedAbsentClassifier`: `getAll`, `keySet`, `containsKey`, `countKey` and `count` return empty for an absent classifier and correct results for a present one, and a counting inner collection asserts that nothing is scanned in the absent case, so the optimization is pinned and not just its answer. A match condition outside the category still scans, which is also asserted.

`./gradlew build` passes on all three loaders.

## Notes for review

* This changes the behaviour of every IntegratedDynamics storage lookup. It needs a CyclopsCore version bump, and dependent mods will need to require it.
* Changes 2 and 3 stand on their own and could be split out if you would rather take them separately. Change 2 in particular is a fix for a pre-existing bug and helps regardless of the hash.
* `IngredientMapWrappedAdapter.iterator()` calls `collection.get(key)` per key while iterating the key set, hashing every entry twice. #232 already fixes that; it applies cleanly on top of this.
* `getItemStackHashCode` is byte identical on `master-1.21-lts`, and `IngredientMapSingleClassified` has the same fall-through there, so both fixes apply. Given the upmerge direction you may want them there first.

## What was not verified

* No client side profiling informed changes 2 and 3; they were driven by server side profiles and the index benchmarks.
* The terminal numbers are loopback medians after warm-up, not a statistically rigorous sample.
* Fabric and Forge keep the common `hasComponentPatch` implementation, which allocates a patch instance for stacks that carry one. That path was not benchmarked; only NeoForge was.