### PR TITLE
Hash an ingredient key once per index update

### DIFF
--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IIngredientMapMutable.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IIngredientMapMutable.java
@@ -5,6 +5,7 @@ import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 
 /**
  * A mutable mapping from ingredient component instances to values of any type.
@@ -88,6 +89,33 @@ public interface IIngredientMapMutable<T, M, V> extends IIngredientMap<T, M, V> 
             removed += removeAll(instance, matchCondition);
         }
         return removed;
+    }
+
+    /**
+     * Compute a new value for the given key instance, following {@link Map#compute} semantics.
+     *
+     * The remapping function is passed the key and the currently mapped value, or null when the key
+     * is absent. Returning null removes the mapping, returning anything else stores it.
+     *
+     * Implementations back onto a hash of the key instance, which for some component types is
+     * expensive. Doing this in one call rather than a get followed by a put lets them hash once.
+     *
+     * @param key An instance key.
+     * @param remappingFunction A function computing the new value from the key and the old value.
+     * @return The new value associated with the key, or null if none.
+     */
+    @Nullable
+    default V compute(T key, BiFunction<T, V, V> remappingFunction) {
+        V oldValue = get(key);
+        V newValue = remappingFunction.apply(key, oldValue);
+        if (newValue == null) {
+            if (oldValue != null) {
+                remove(key);
+            }
+        } else {
+            put(key, newValue);
+        }
+        return newValue;
     }
 
     /**

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientCollectionPrototypeMap.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientCollectionPrototypeMap.java
@@ -52,14 +52,14 @@ public class IngredientCollectionPrototypeMap<T, M> extends IngredientCollection
     public boolean add(T instance) {
         IIngredientMatcher<T, M> matcher = getComponent().getMatcher();
         T prototype = getPrototype(instance);
-        Long value = ingredients.get(prototype);
-        long existingValue = value == null ? 0 : value;
-        long newValue = Math.addExact(existingValue, matcher.getQuantity(instance));
-        if (newValue != 0) {
-            ingredients.put(prototype, newValue);
-        } else {
-            ingredients.remove(prototype);
-        }
+        long quantity = matcher.getQuantity(instance);
+        // Computed in one call so the prototype is hashed once rather than once to read and once
+        // to write. Hashing a prototype is the dominant cost here for component-bearing instances.
+        ingredients.compute(prototype, (key, value) -> {
+            long existingValue = value == null ? 0 : value;
+            long newValue = Math.addExact(existingValue, quantity);
+            return newValue == 0 ? null : newValue;
+        });
         return true;
     }
 
@@ -67,17 +67,20 @@ public class IngredientCollectionPrototypeMap<T, M> extends IngredientCollection
     public boolean remove(T instance) {
         IIngredientMatcher<T, M> matcher = getComponent().getMatcher();
         T prototype = getPrototype(instance);
-        Long value = ingredients.get(prototype);
-        long existingValue = value == null ? 0 : value;
         long currentValue = matcher.getQuantity(instance);
-        if (currentValue == existingValue) {
-            ingredients.remove(prototype);
-            return true;
-        } else if (currentValue < existingValue || isNegativeQuantities()) {
-            ingredients.put(prototype, existingValue - currentValue);
-            return true;
-        }
-        return false;
+        boolean[] removed = new boolean[1];
+        ingredients.compute(prototype, (key, value) -> {
+            long existingValue = value == null ? 0 : value;
+            if (currentValue == existingValue) {
+                removed[0] = true;
+                return null;
+            } else if (currentValue < existingValue || isNegativeQuantities()) {
+                removed[0] = true;
+                return existingValue - currentValue;
+            }
+            return value;
+        });
+        return removed[0];
     }
 
     @Override

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapSingleClassified.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapSingleClassified.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 /**
@@ -110,6 +111,29 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
 
         }
         return null;
+    }
+
+    @Nullable
+    @Override
+    public V compute(T key, BiFunction<T, V, V> remappingFunction) {
+        C classifier = getClassifier(key);
+        IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(classifier);
+        if (map == null) {
+            // Nothing is stored under this classifier, so only an insertion can come out of this
+            V newValue = remappingFunction.apply(key, null);
+            if (newValue != null) {
+                getOrCreateClassifiedCollection(classifier).put(key, newValue);
+                this.size++;
+            }
+            return newValue;
+        }
+        int sizeBefore = map.size();
+        V newValue = map.compute(key, remappingFunction);
+        this.size += map.size() - sizeBefore;
+        if (map.isEmpty()) {
+            this.classifiedMaps.remove(classifier);
+        }
+        return newValue;
     }
 
     @Override

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapWrappedAdapter.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapWrappedAdapter.java
@@ -9,6 +9,7 @@ import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 /**
  * An abstract ingredient map adapter.
@@ -66,6 +67,14 @@ public abstract class IngredientMapWrappedAdapter<T, M, V, C extends Map<Ingredi
     @Override
     public V get(T key) {
         return this.collection.get(wrap(key));
+    }
+
+    @Nullable
+    @Override
+    public V compute(T key, BiFunction<T, V, V> remappingFunction) {
+        // One wrapper, so the key is hashed once instead of once for the get and once for the put
+        return this.collection.compute(wrap(key),
+                (wrapper, value) -> remappingFunction.apply(wrapper.getInstance(), value));
     }
 
     @Override

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestIngredientMapCompute.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestIngredientMapCompute.java
@@ -1,0 +1,138 @@
+package org.cyclops.cyclopscore.ingredient.collection;
+
+import org.cyclops.cyclopscore.ingredient.ComplexStack;
+import org.cyclops.cyclopscore.ingredient.IngredientComponentStubs;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * {@link IIngredientMapMutable#compute} across the map implementations.
+ *
+ * It exists so that a read followed by a write can hash the key once instead of twice, so the
+ * results have to stay identical to doing both separately.
+ *
+ * @author rubensworks
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestIngredientMapCompute {
+
+    private static final ComplexStack A01 = new ComplexStack(ComplexStack.Group.A, 0, 1, null);
+    private static final ComplexStack A12 = new ComplexStack(ComplexStack.Group.A, 1, 2, null);
+    private static final ComplexStack B01 = new ComplexStack(ComplexStack.Group.B, 0, 1, null);
+
+    public Stream<Arguments> maps() {
+        return Stream.<Supplier<IIngredientMapMutable<ComplexStack, Integer, String>>>of(
+                () -> new IngredientHashMap<>(IngredientComponentStubs.COMPLEX),
+                () -> new IngredientTreeMap<>(IngredientComponentStubs.COMPLEX),
+                () -> new IngredientMapSingleClassified<>(IngredientComponentStubs.COMPLEX,
+                        () -> new IngredientHashMap<>(IngredientComponentStubs.COMPLEX),
+                        IngredientComponentStubs.COMPLEX.getCategoryTypes().get(0))
+        ).map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testInsertsWhenAbsent(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        assertThat(map.compute(A01, (key, value) -> {
+            assertThat(value, is(nullValue()));
+            return "first";
+        }), is("first"));
+        assertThat(map.get(A01), is("first"));
+        assertThat(map.size(), is(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testUpdatesWhenPresent(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        map.put(A01, "first");
+        assertThat(map.compute(A01, (key, value) -> value + "+second"), is("first+second"));
+        assertThat(map.get(A01), is("first+second"));
+        assertThat(map.size(), is(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testRemovesOnNull(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        map.put(A01, "first");
+        map.put(A12, "other");
+        assertThat(map.compute(A01, (key, value) -> null), is(nullValue()));
+        assertThat(map.get(A01), is(nullValue()));
+        assertThat(map.get(A12), is("other"));
+        assertThat(map.size(), is(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testNullOnAbsentIsNoOp(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        assertThat(map.compute(A01, (key, value) -> null), is(nullValue()));
+        assertThat(map.size(), is(0));
+        assertThat(map.isEmpty(), is(true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testKeyIsPassedThrough(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        map.compute(A01, (key, value) -> {
+            assertThat(key, is(A01));
+            return "v";
+        });
+    }
+
+    /**
+     * The classified map keeps its own size and drops classifiers that run empty, so computing
+     * away the last entry of a classifier has to clean up just as a remove would.
+     */
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testSizeTracksAcrossClassifiers(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        map.compute(A01, (key, value) -> "a");
+        map.compute(B01, (key, value) -> "b");
+        assertThat(map.size(), is(2));
+        map.compute(B01, (key, value) -> null);
+        assertThat(map.size(), is(1));
+        assertThat(map.get(A01), is("a"));
+        assertThat(map.get(B01), is(nullValue()));
+        map.compute(B01, (key, value) -> "b again");
+        assertThat(map.size(), is(2));
+        assertThat(map.get(B01), is("b again"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testMatchesGetThenPut(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> computed = factory.get();
+        IIngredientMapMutable<ComplexStack, Integer, String> manual = factory.get();
+        ComplexStack[] keys = {A01, A12, B01, A01, B01, A12};
+        for (int i = 0; i < keys.length; i++) {
+            ComplexStack key = keys[i];
+            int step = i;
+            computed.compute(key, (k, value) -> step % 3 == 2 ? null : (value == null ? "v" + step : value + "v" + step));
+            String oldValue = manual.get(key);
+            String newValue = step % 3 == 2 ? null : (oldValue == null ? "v" + step : oldValue + "v" + step);
+            if (newValue == null) {
+                manual.remove(key);
+            } else {
+                manual.put(key, newValue);
+            }
+            assertThat(computed.size(), is(manual.size()));
+            for (ComplexStack probe : new ComplexStack[]{A01, A12, B01}) {
+                assertThat(computed.get(probe), is(manual.get(probe)));
+            }
+        }
+    }
+}


### PR DESCRIPTION
An ingredient map hashes its key on every operation, and for ItemStack that hash walks a data component map. The update paths all read then write, and `IngredientMapWrappedAdapter` builds its own wrapper inside each of `get`, `put` and `remove`, so one logical update hashed the same key twice. Storage networks then run every change twice over, once for its own channel and once for the wildcard channel, so it multiplies.

`IIngredientMapMutable` gains a `compute` method with `Map.compute` semantics. The default implementation is the old read-then-write, so every existing implementation stays correct without changing. `IngredientMapWrappedAdapter` builds one wrapper and hands it to the backing map's own `compute`. `IngredientMapSingleClassified` delegates to the classifier's sub-map while keeping its size counter and its empty-classifier cleanup.

`IngredientCollectionPrototypeMap.add` and `remove` use it. Component types whose hash is cheap see no difference either way.

The companion change on the IntegratedDynamics side is CyclopsMC/IntegratedDynamics#1725, which converts `IngredientPositionsIndex.addPosition` and `removePosition`.

## Numbers

IntegratedDynamics index benchmarks, ms per operation, medians of six runs each, alternating between the two configurations within one session so that session drift falls on both equally. Both sides carry the fixes from #238, since this only pays off once hashing costs something.

| benchmark | without compute | with compute | factor |
|---|---:|---:|---|
| index_modification_single_item | 0.001162 | 0.000688 | **41% faster** |
| index_modification_few_items | 0.001084 | 0.000726 | **33% faster** |
| index_modification_heavy_components | 0.002510 | 0.002077 | **17% faster** |
| index_modification_mixed | 0.000713 | 0.000667 | 6% faster |
| index_modification_plain | 0.000530 | 0.000507 | 4% faster |
| index_modification | 0.001246 | 0.001381 | 11% slower |

Lookup benchmarks all land within 10% either way with no consistent direction, which is expected: they do not read-then-write, so there is nothing for this to collapse.

### What that means, honestly

The win is concentrated where hashing genuinely dominates a modification: many component variants of one item, or a large component payload. Those are the shapes a storage network hurts on.

It is much weaker on the realistic shapes. On `mixed`, which is one instance in ten carrying a component, the median improves 6% and the distributions overlap (without: 0.000649 to 0.000763; with: 0.000593 to 0.000902). On `plain` it is 4% and likewise inside the spread. The reason is that #238 already skips the component hash entirely for stacks carrying no patch, so on those shapes there is little hashing left to halve.

`index_modification` on the spread shape reads 11% slower, but that benchmark runs first in the sequence and absorbs JIT warm-up. Its two distributions overlap almost completely (without: 0.001088 to 0.001568; with: 0.000974 to 0.002894, the top value being a clear outlier). I would not read a regression into it, but I am not able to rule one out either.

I predicted this would be worth about a third of the remaining modification cost. That held for the hash-dominated shapes and overestimated the realistic ones. Reporting the miss rather than the prediction.

## Recommendation

Worth taking, but not urgently. It is a strict reduction in work, the API mirrors `Map.compute` so it is not exotic, the default keeps every other implementation correct untouched, and it helps most exactly where large storage networks hurt. But the realistic-mix gain is inside the measurement spread, so if you would rather not widen `IIngredientMapMutable` for that, closing this is a defensible call.

## Tests

`TestIngredientMapCompute` covers insert, update, remove, a null remapping on an absent key, key pass-through, and size tracking across classifiers, over `IngredientHashMap`, `IngredientTreeMap` and `IngredientMapSingleClassified`. It also drives a sequence of computes against a second map doing the get-then-put by hand and asserts the two stay identical after every step.

`./gradlew build` passes on all three loaders.

## Notes for review

* `IngredientMapMultiClassified` keeps the default implementation. It is correct, just not collapsed; the positions index never uses it.
* This is independent of #238 and merges cleanly with it. I trial-merged both onto master locally and nothing conflicted.