### PR TITLE
Fix ItemStack hashing and classified ingredient lookups

### DIFF
--- a/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
@@ -97,21 +97,6 @@ public abstract class ItemStackHelpersCommon implements IItemStackHelpers {
         int result = 1;
         result = 37 * result + stack.getCount();
         result = 37 * result + stack.getItem().hashCode();
-        // Data components have to be part of the hash, because equality compares them.
-        // Leaving them out makes every stack of the same item hash alike, so hash-based
-        // ingredient collections collapse into one bucket per item and every lookup turns
-        // into a scan doing full component comparisons. This is what made large storage
-        // networks scale quadratically. The exclusion dates from NBT tags, which were
-        // expensive to hash; component maps are not.
-        //
-        // Only stacks carrying a patch need it. A component map hashes its prototype alongside its
-        // patch, and the prototype is the item's defaults, which the item hashed above already
-        // stands for. Hashing it again distinguishes nothing, and it is the dominant cost for the
-        // plain stacks that most of a storage network consists of.
-        //
-        // This stays consistent with equality because the patch is kept sanitized: setting a
-        // component to its default removes it from the patch rather than storing it, so two stacks
-        // of one item have equal components exactly when they have equal patches.
         if (hasComponentPatch(stack)) {
             result = 37 * result + stack.getComponents().hashCode();
         }

--- a/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
@@ -103,11 +103,36 @@ public abstract class ItemStackHelpersCommon implements IItemStackHelpers {
         // into a scan doing full component comparisons. This is what made large storage
         // networks scale quadratically. The exclusion dates from NBT tags, which were
         // expensive to hash; component maps are not.
-        // Mirrors ItemStack.hashItemAndComponents, which vanilla uses for the same purpose.
-        result = 37 * result + stack.getComponents().hashCode();
+        //
+        // Only stacks carrying a patch need it. A component map hashes its prototype alongside its
+        // patch, and the prototype is the item's defaults, which the item hashed above already
+        // stands for. Hashing it again distinguishes nothing, and it is the dominant cost for the
+        // plain stacks that most of a storage network consists of.
+        //
+        // This stays consistent with equality because the patch is kept sanitized: setting a
+        // component to its default removes it from the patch rather than storing it, so two stacks
+        // of one item have equal components exactly when they have equal patches.
+        if (hasComponentPatch(stack)) {
+            result = 37 * result + stack.getComponents().hashCode();
+        }
         // Not factoring in capability compatibility. Doing so would require either reflection (slow)
         // or an access transformer, it's highly unlikely that it'd be the only difference between
         // many ItemStacks in practice, and occasional hash code collisions are okay.
         return result;
+    }
+
+    /**
+     * If the given stack carries data components that differ from its item's defaults.
+     *
+     * Only those have to take part in {@link #getItemStackHashCode(ItemStack)}.
+     *
+     * @param stack A non-empty stack.
+     * @return If the stack has a non-empty component patch.
+     */
+    protected boolean hasComponentPatch(ItemStack stack) {
+        // Vanilla exposes the patch only by building one. That costs nothing for the stacks this
+        // is here to catch, as an empty patch yields the shared empty instance. Loaders that can
+        // answer without building anything should override this.
+        return !stack.getComponentsPatch().isEmpty();
     }
 }

--- a/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
@@ -115,9 +115,6 @@ public abstract class ItemStackHelpersCommon implements IItemStackHelpers {
      * @return If the stack has a non-empty component patch.
      */
     protected boolean hasComponentPatch(ItemStack stack) {
-        // Vanilla exposes the patch only by building one. That costs nothing for the stacks this
-        // is here to catch, as an empty patch yields the shared empty instance. Loaders that can
-        // answer without building anything should override this.
         return !stack.getComponentsPatch().isEmpty();
     }
 }

--- a/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersCommon.java
@@ -97,9 +97,14 @@ public abstract class ItemStackHelpersCommon implements IItemStackHelpers {
         int result = 1;
         result = 37 * result + stack.getCount();
         result = 37 * result + stack.getItem().hashCode();
-        // Tags can be very large, and expensive to calculate, which is not needed for hashCodes.
-        // CompoundTag tagCompound = stack.getTag();
-        // result = 37 * result + (tagCompound != null ? tagCompound.hashCode() : 0);
+        // Data components have to be part of the hash, because equality compares them.
+        // Leaving them out makes every stack of the same item hash alike, so hash-based
+        // ingredient collections collapse into one bucket per item and every lookup turns
+        // into a scan doing full component comparisons. This is what made large storage
+        // networks scale quadratically. The exclusion dates from NBT tags, which were
+        // expensive to hash; component maps are not.
+        // Mirrors ItemStack.hashItemAndComponents, which vanilla uses for the same purpose.
+        result = 37 * result + stack.getComponents().hashCode();
         // Not factoring in capability compatibility. Doing so would require either reflection (slow)
         // or an access transformer, it's highly unlikely that it'd be the only difference between
         // many ItemStacks in practice, and occasional hash code collisions are okay.

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersNeoForge.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersNeoForge.java
@@ -15,4 +15,10 @@ public class ItemStackHelpersNeoForge extends ItemStackHelpersCommon {
     public ItemStack getCraftingRemainingItem(ItemStack itemStack) {
         return itemStack.getCraftingRemainingItem();
     }
+
+    @Override
+    protected boolean hasComponentPatch(ItemStack stack) {
+        // Answers without building the patch instance that the common implementation needs
+        return !stack.isComponentsPatchEmpty();
+    }
 }

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersNeoForge.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/helper/ItemStackHelpersNeoForge.java
@@ -18,7 +18,6 @@ public class ItemStackHelpersNeoForge extends ItemStackHelpersCommon {
 
     @Override
     protected boolean hasComponentPatch(ItemStack stack) {
-        // Answers without building the patch instance that the common implementation needs
         return !stack.isComponentsPatchEmpty();
     }
 }

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientCollectionSingleClassified.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientCollectionSingleClassified.java
@@ -176,13 +176,17 @@ public class IngredientCollectionSingleClassified<T, M, C, L extends IIngredient
         }
         if (appliesToClassifier(matchCondition)) {
             IIngredientCollectionMutable<T, M> collection = this.classifiedCollections.get(getClassifier(instance));
-            if (collection != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return collection.size();
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return collection.count(instance, subMatchCondition);
-                }
+            if (collection == null) {
+                // The match condition requires the classifier to be equal, so an absent classifier
+                // means nothing can match. Falling through to the unclassified path here would scan
+                // every instance for a result that is known to be zero.
+                return 0;
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return collection.size();
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return collection.count(instance, subMatchCondition);
             }
         }
         return super.count(instance, matchCondition);

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapSingleClassified.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapSingleClassified.java
@@ -8,6 +8,7 @@ import org.cyclops.commoncapabilities.api.ingredient.IngredientComponentCategory
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -121,13 +122,17 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
     public boolean containsKey(T instance, M matchCondition) {
         if (appliesToClassifier(matchCondition)) {
             IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(getClassifier(instance));
-            if (map != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return true;
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return map.containsKey(instance, subMatchCondition);
-                }
+            if (map == null) {
+                // The match condition requires the classifier to be equal, so an absent classifier
+                // means nothing can match. Falling through to the unclassified path here would scan
+                // every key for a result that is known to be empty.
+                return false;
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return true;
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return map.containsKey(instance, subMatchCondition);
             }
         }
         return super.containsKey(instance, matchCondition);
@@ -137,13 +142,14 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
     public int countKey(T instance, M matchCondition) {
         if (appliesToClassifier(matchCondition)) {
             IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(getClassifier(instance));
-            if (map != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return map.size();
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return map.countKey(instance, subMatchCondition);
-                }
+            if (map == null) {
+                return 0;
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return map.size();
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return map.countKey(instance, subMatchCondition);
             }
         }
         return super.countKey(instance, matchCondition);
@@ -192,13 +198,14 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
     public Collection<V> getAll(T key, M matchCondition) {
         if (appliesToClassifier(matchCondition)) {
             IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(getClassifier(key));
-            if (map != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return map.values();
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return map.getAll(key, subMatchCondition);
-                }
+            if (map == null) {
+                return Collections.emptyList();
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return map.values();
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return map.getAll(key, subMatchCondition);
             }
         }
         return super.getAll(key, matchCondition);
@@ -208,13 +215,14 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
     public IngredientSet<T, M> keySet(T key, M matchCondition) {
         if (appliesToClassifier(matchCondition)) {
             IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(getClassifier(key));
-            if (map != null) {
-                if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
-                    return map.keySet();
-                } else {
-                    M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
-                    return map.keySet(key, subMatchCondition);
-                }
+            if (map == null) {
+                return new IngredientHashSet<>(getComponent());
+            }
+            if (Objects.equals(getCategoryType().getMatchCondition(), matchCondition)) {
+                return map.keySet();
+            } else {
+                M subMatchCondition = getComponent().getMatcher().withoutCondition(matchCondition, getCategoryType().getMatchCondition());
+                return map.keySet(key, subMatchCondition);
             }
         }
         return super.keySet(key, matchCondition);

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
@@ -1,0 +1,109 @@
+package org.cyclops.cyclopscore.helper;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import org.cyclops.cyclopscore.inventory.ItemDummy;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Unit tests for the ItemStack hash code of {@link ItemStackHelpersCommon}.
+ *
+ * The hash has to take data components into account. Ingredient collections key on it, and a
+ * component-blind hash puts every stack of the same item in one bucket, which turns their
+ * lookups into scans over full component comparisons.
+ *
+ * @author rubensworks
+ */
+public class TestItemStackHelpersHashCode {
+
+    static {
+        ((MappedRegistry) BuiltInRegistries.ITEM).unfreeze(true);
+    }
+
+    private static final Item ITEM1 = new ItemDummy();
+    private static final Item ITEM2 = new ItemDummy();
+
+    static {
+        ((Holder.Reference<Item>) ITEM1.builtInRegistryHolder()).bindComponents(DataComponentMap.EMPTY);
+        ((Holder.Reference<Item>) ITEM2.builtInRegistryHolder()).bindComponents(DataComponentMap.EMPTY);
+    }
+
+    private static int hash(ItemStack stack) {
+        return new ItemStackHelpersCommon() {}.getItemStackHashCode(stack);
+    }
+
+    private static ItemStack named(Item item, int count, String name) {
+        ItemStack stack = new ItemStack(item, count);
+        stack.set(DataComponents.CUSTOM_NAME, Component.literal(name));
+        return stack;
+    }
+
+    @Test
+    public void testEqualStacksHashEqual() {
+        assertThat(hash(new ItemStack(ITEM1)), is(hash(new ItemStack(ITEM1))));
+        assertThat(hash(new ItemStack(ITEM1, 7)), is(hash(new ItemStack(ITEM1, 7))));
+        assertThat(hash(named(ITEM1, 3, "a")), is(hash(named(ITEM1, 3, "a"))));
+        assertThat(hash(ItemStack.EMPTY), is(hash(ItemStack.EMPTY)));
+    }
+
+    @Test
+    public void testDifferentItemsHashDifferently() {
+        assertThat(hash(new ItemStack(ITEM1)), is(not(hash(new ItemStack(ITEM2)))));
+    }
+
+    @Test
+    public void testDifferentCountsHashDifferently() {
+        assertThat(hash(new ItemStack(ITEM1, 1)), is(not(hash(new ItemStack(ITEM1, 2)))));
+    }
+
+    /**
+     * The regression this guards: stacks of one item differing only by components used to share a hash.
+     */
+    @Test
+    public void testComponentsAffectHash() {
+        assertThat(hash(named(ITEM1, 1, "a")), is(not(hash(named(ITEM1, 1, "b")))));
+        assertThat(hash(new ItemStack(ITEM1)), is(not(hash(named(ITEM1, 1, "a")))));
+    }
+
+    /**
+     * A single differing hash could be luck. Over a sample of same-item stacks the hash has to
+     * spread, or hash-based collections degrade to linear scans.
+     */
+    @Test
+    public void testComponentVariantsSpreadOverManyBuckets() {
+        int samples = 1000;
+        Set<Integer> hashes = new HashSet<>();
+        for (int i = 0; i < samples; i++) {
+            hashes.add(hash(named(ITEM1, 1, "variant " + i)));
+        }
+        assertThat("Component variants of one item have to produce distinct hashes",
+                hashes.size() > samples * 0.99, is(true));
+    }
+
+    /**
+     * The hash may never distinguish two stacks that count as equal, or lookups miss.
+     */
+    @Test
+    public void testHashIsConsistentWithComponentEquality() {
+        for (int i = 0; i < 100; i++) {
+            ItemStack a = named(ITEM1, 1 + (i % 5), "variant " + i);
+            ItemStack b = named(ITEM1, 1 + (i % 5), "variant " + i);
+            assertThat(ItemStack.isSameItemSameComponents(a, b), is(true));
+            assertThat(a.getCount(), is(b.getCount()));
+            assertThat(hash(a), is(hash(b)));
+        }
+    }
+}

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
@@ -41,8 +41,10 @@ public class TestItemStackHelpersHashCode {
         ((Holder.Reference<Item>) ITEM2.builtInRegistryHolder()).bindComponents(DataComponentMap.EMPTY);
     }
 
+    private static final IItemStackHelpers HELPERS = new ItemStackHelpersNeoForge();
+
     private static int hash(ItemStack stack) {
-        return new ItemStackHelpersCommon() {}.getItemStackHashCode(stack);
+        return HELPERS.getItemStackHashCode(stack);
     }
 
     private static ItemStack named(Item item, int count, String name) {

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
@@ -1,17 +1,21 @@
 package org.cyclops.cyclopscore.helper;
 
+import net.minecraft.DetectedVersion;
+import net.minecraft.SharedConstants;
 import net.minecraft.core.Holder;
 import net.minecraft.core.MappedRegistry;
-import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.server.Bootstrap;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.cyclops.cyclopscore.inventory.ItemDummy;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -30,15 +34,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestItemStackHelpersHashCode {
 
     static {
-        ((MappedRegistry) BuiltInRegistries.ITEM).unfreeze(true);
+        SharedConstants.setVersion(DetectedVersion.BUILT_IN);
+        Bootstrap.bootStrap();
+        ((MappedRegistry) BuiltInRegistries.ITEM).unfreeze();
     }
 
     private static final Item ITEM1 = new ItemDummy();
     private static final Item ITEM2 = new ItemDummy();
 
     static {
-        ((Holder.Reference<Item>) ITEM1.builtInRegistryHolder()).bindComponents(DataComponentMap.EMPTY);
-        ((Holder.Reference<Item>) ITEM2.builtInRegistryHolder()).bindComponents(DataComponentMap.EMPTY);
+        // Same intrusive-holder bootstrap the other item tests use
+        try {
+            Field field = MappedRegistry.class.getDeclaredField("unregisteredIntrusiveHolders");
+            field.setAccessible(true);
+            Map<Item, Holder.Reference<Item>> delegates = ((Map<Item, Holder.Reference<Item>>) field
+                    .get(BuiltInRegistries.ITEM));
+            delegates.put(ITEM1, Holder.Reference.createIntrusive(BuiltInRegistries.ITEM.asLookup(), ITEM1));
+            delegates.put(ITEM2, Holder.Reference.createIntrusive(BuiltInRegistries.ITEM.asLookup(), ITEM2));
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static final IItemStackHelpers HELPERS = new ItemStackHelpersNeoForge();

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/helper/TestItemStackHelpersHashCode.java
@@ -96,6 +96,32 @@ public class TestItemStackHelpersHashCode {
     }
 
     /**
+     * Stacks carrying no component patch skip the component hash, so this pins that they still
+     * spread over items and counts, and still agree with equality.
+     */
+    @Test
+    public void testPlainStacksSpreadOverItemsAndCounts() {
+        assertThat(hash(new ItemStack(ITEM1, 1)), is(not(hash(new ItemStack(ITEM2, 1)))));
+        assertThat(hash(new ItemStack(ITEM1, 1)), is(not(hash(new ItemStack(ITEM1, 2)))));
+        assertThat(hash(new ItemStack(ITEM1, 5)), is(hash(new ItemStack(ITEM1, 5))));
+    }
+
+    /**
+     * A stack whose only component is set back to its default carries no patch any more, so it is
+     * equal to the plain stack and has to hash like one.
+     */
+    @Test
+    public void testComponentSetBackToDefaultHashesAsPlain() {
+        ItemStack plain = new ItemStack(ITEM1);
+        ItemStack restored = new ItemStack(ITEM1);
+        restored.set(DataComponents.CUSTOM_NAME, Component.literal("a"));
+        assertThat(hash(restored), is(not(hash(plain))));
+        restored.set(DataComponents.CUSTOM_NAME, null);
+        assertThat(ItemStack.isSameItemSameComponents(plain, restored), is(true));
+        assertThat(hash(restored), is(hash(plain)));
+    }
+
+    /**
      * The hash may never distinguish two stacks that count as equal, or lookups miss.
      */
     @Test

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestSingleClassifiedAbsentClassifier.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestSingleClassifiedAbsentClassifier.java
@@ -1,0 +1,191 @@
+package org.cyclops.cyclopscore.ingredient.collection;
+
+import org.cyclops.cyclopscore.ingredient.ComplexStack;
+import org.cyclops.cyclopscore.ingredient.IngredientComponentStubs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Queries on a single-classified collection whose classifier holds nothing.
+ *
+ * A match condition that covers the category type can only match instances sharing the query's
+ * classifier, so an absent classifier means an empty result. These lookups must say so directly
+ * rather than falling back on a scan over every classifier, which is both slower and grows with
+ * the size of the whole collection instead of with the size of one classifier.
+ *
+ * @author rubensworks
+ */
+public class TestSingleClassifiedAbsentClassifier {
+
+    private static final int GROUP = ComplexStack.Match.GROUP;
+    private static final int GROUP_META = ComplexStack.Match.GROUP | ComplexStack.Match.META;
+
+    private static final ComplexStack A01 = new ComplexStack(ComplexStack.Group.A, 0, 1, null);
+    private static final ComplexStack A12 = new ComplexStack(ComplexStack.Group.A, 1, 2, null);
+    private static final ComplexStack B01 = new ComplexStack(ComplexStack.Group.B, 0, 1, null);
+    /**
+     * Nothing of this group is ever added.
+     */
+    private static final ComplexStack C01 = new ComplexStack(ComplexStack.Group.C, 0, 1, null);
+
+    /**
+     * Counts every time an inner collection is asked to iterate, so that a fallback scan over all
+     * classifiers becomes visible rather than only slow.
+     */
+    private AtomicInteger innerIterations;
+
+    private IngredientCollectionSingleClassified<ComplexStack, Integer, ?, IIngredientCollectionMutable<ComplexStack, Integer>> collection;
+    private IngredientMapSingleClassified<ComplexStack, Integer, String, ?> map;
+
+    @BeforeEach
+    public void before() {
+        this.innerIterations = new AtomicInteger();
+
+        this.collection = new IngredientCollectionSingleClassified<>(IngredientComponentStubs.COMPLEX,
+                () -> new CountingSet(this.innerIterations),
+                IngredientComponentStubs.COMPLEX.getCategoryTypes().get(0));
+        this.collection.add(A01);
+        this.collection.add(A12);
+        this.collection.add(B01);
+
+        this.map = new IngredientMapSingleClassified<>(IngredientComponentStubs.COMPLEX,
+                () -> new CountingMap(this.innerIterations),
+                IngredientComponentStubs.COMPLEX.getCategoryTypes().get(0));
+        this.map.put(A01, "a01");
+        this.map.put(A12, "a12");
+        this.map.put(B01, "b01");
+
+        this.innerIterations.set(0);
+    }
+
+    @Test
+    public void testCollectionCountAbsentClassifier() {
+        assertThat(collection.count(C01, GROUP), is(0));
+        assertThat(collection.count(C01, GROUP_META), is(0));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testCollectionCountPresentClassifier() {
+        assertThat(collection.count(A01, GROUP), is(2));
+        assertThat(collection.count(B01, GROUP), is(1));
+        assertThat(collection.count(A01, GROUP_META), is(1));
+    }
+
+    @Test
+    public void testMapCountKeyAbsentClassifier() {
+        assertThat(map.countKey(C01, GROUP), is(0));
+        assertThat(map.countKey(C01, GROUP_META), is(0));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testMapCountKeyPresentClassifier() {
+        assertThat(map.countKey(A01, GROUP), is(2));
+        assertThat(map.countKey(B01, GROUP), is(1));
+        assertThat(map.countKey(A01, GROUP_META), is(1));
+    }
+
+    @Test
+    public void testMapContainsKeyAbsentClassifier() {
+        assertThat(map.containsKey(C01, GROUP), is(false));
+        assertThat(map.containsKey(C01, GROUP_META), is(false));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testMapContainsKeyPresentClassifier() {
+        assertThat(map.containsKey(A01, GROUP), is(true));
+        assertThat(map.containsKey(A01, GROUP_META), is(true));
+    }
+
+    @Test
+    public void testMapGetAllAbsentClassifier() {
+        assertThat(map.getAll(C01, GROUP).isEmpty(), is(true));
+        assertThat(map.getAll(C01, GROUP_META).isEmpty(), is(true));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testMapGetAllPresentClassifier() {
+        assertThat(map.getAll(A01, GROUP).size(), is(2));
+        assertThat(map.getAll(B01, GROUP).size(), is(1));
+        assertThat(map.getAll(A01, GROUP_META).size(), is(1));
+    }
+
+    @Test
+    public void testMapKeySetAbsentClassifier() {
+        assertThat(map.keySet(C01, GROUP).isEmpty(), is(true));
+        assertThat(map.keySet(C01, GROUP_META).isEmpty(), is(true));
+        assertThat(innerIterations.get(), is(0));
+    }
+
+    @Test
+    public void testMapKeySetPresentClassifier() {
+        assertThat(map.keySet(A01, GROUP).size(), is(2));
+        assertThat(map.keySet(B01, GROUP).size(), is(1));
+        assertThat(map.keySet(A01, GROUP_META).size(), is(1));
+    }
+
+    /**
+     * A match condition that does not cover the category type can not be answered by the
+     * classifier, so it still has to visit the inner collections.
+     */
+    @Test
+    public void testMatchConditionOutsideClassifierStillScans() {
+        assertThat(map.countKey(C01, ComplexStack.Match.META), is(2));
+        assertThat(innerIterations.get() > 0, is(true));
+    }
+
+    private static class CountingSet extends IngredientHashSet<ComplexStack, Integer> {
+
+        private final AtomicInteger counter;
+
+        public CountingSet(AtomicInteger counter) {
+            super(IngredientComponentStubs.COMPLEX);
+            this.counter = counter;
+        }
+
+        @Override
+        public Iterator<ComplexStack> iterator() {
+            this.counter.incrementAndGet();
+            return super.iterator();
+        }
+    }
+
+    private static class CountingMap extends IngredientHashMap<ComplexStack, Integer, String> {
+
+        private final AtomicInteger counter;
+
+        public CountingMap(AtomicInteger counter) {
+            super(IngredientComponentStubs.COMPLEX);
+            this.counter = counter;
+        }
+
+        @Override
+        public Iterator<Map.Entry<ComplexStack, String>> iterator() {
+            this.counter.incrementAndGet();
+            return super.iterator();
+        }
+
+        @Override
+        public IngredientSet<ComplexStack, Integer> keySet() {
+            this.counter.incrementAndGet();
+            return super.keySet();
+        }
+
+        @Override
+        public Collection<String> values() {
+            this.counter.incrementAndGet();
+            return super.values();
+        }
+    }
+}

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestSingleClassifiedAbsentClassifier.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestSingleClassifiedAbsentClassifier.java
@@ -2,8 +2,8 @@ package org.cyclops.cyclopscore.ingredient.collection;
 
 import org.cyclops.cyclopscore.ingredient.ComplexStack;
 import org.cyclops.cyclopscore.ingredient.IngredientComponentStubs;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -45,7 +45,7 @@ public class TestSingleClassifiedAbsentClassifier {
     private IngredientCollectionSingleClassified<ComplexStack, Integer, ?, IIngredientCollectionMutable<ComplexStack, Integer>> collection;
     private IngredientMapSingleClassified<ComplexStack, Integer, String, ?> map;
 
-    @BeforeEach
+    @Before
     public void before() {
         this.innerIterations = new AtomicInteger();
 


### PR DESCRIPTION
The 1.21 version of #238. Same three changes, measured on 1.21.1, where the effect is larger than on 26.1.

## 1. The ItemStack hash ignored data components

`IItemStackHelpers.getItemStackHashCode` hashed only the count and the item, while equality compares components in full. Every stack of the same item therefore hashed alike, so the hash-based ingredient collections collapsed into one bucket per item type and each lookup in such a bucket became a linear scan doing full component comparisons.

The method still carried the commented-out NBT hashing it inherited from before data components, with a note that tags were too expensive to hash. Component maps are not.

## 2. Classified lookups scanned everything when the classifier was empty

A single-classified collection partitions instances by a category type, and ItemStack is classified by its item. When a query's match condition covers that category, every match has to share the query's classifier, so an absent classifier means an empty result. `contains` and `iterator` already returned one directly. `getAll`, `keySet`, `containsKey`, `countKey` and `count` fell through to the unclassified path, which scans every instance to produce a result already known to be empty.

An IntegratedDynamics storage index keeps one classified map per priority level, so an item lookup visits every level, and every level not holding that item scanned all of its entries. This is a pre-existing bug, independent of change 1, and it is why item-only lookups were slow before any of this.

## 3. Plain stacks were hashing their item's default components

A component map hashes its prototype alongside its patch, and the prototype is the item's defaults, which the item already in the hash stands for. For a stack carrying no patch that walk was the entire cost of the hash, and plain stacks are what most of a storage network consists of.

This is safe on 1.21.1 for the same reason as on 26.1: `PatchedDataComponentMap` keeps its patch sanitized. I checked the 1.21.1 sources directly, both `set` and `applyPatch` drop an entry whose value equals the prototype's default rather than storing it, and `hashCode` is `prototype.hashCode() + patch.hashCode() * 31`. Two stacks of one item therefore have equal components exactly when they have equal patches. `ItemStack.isComponentsPatchEmpty()` exists in NeoForge 21.1.2, so the NeoForge override works here too, and vanilla `getComponentsPatch().isEmpty()` backs the common implementation.

## Numbers

IntegratedDynamics index benchmarks on 1.21.1, `PERFORMANCE_BENCHMARK_ENABLED=true ./gradlew runGameTestServer`, ms per operation, medians of three whole runs each side. The shapes are added in CyclopsMC/IntegratedDynamics#PENDING_ID_BENCH.

| benchmark | before | after | |
|---|---:|---:|---|
| index_lookup_item | 9.507505 | 0.001814 | **5241x faster** |
| index_lookup_item_mixed | 1.113108 | 0.001536 | **725x faster** |
| index_lookup_item_plain | 0.299095 | 0.001390 | **215x faster** |
| index_lookup_exact_single_item | 5.151762 | 0.001934 | **2664x faster** |
| index_modification_single_item | 4.780310 | 0.001982 | **2412x faster** |
| index_modification_few_items | 0.219300 | 0.001838 | **119x faster** |
| index_lookup_exact_few_items | 0.092090 | 0.001298 | **71x faster** |
| index_modification | 0.009933 | 0.001686 | 5.9x faster |
| index_lookup_exact | 0.002876 | 0.001129 | 2.5x faster |
| index_modification_heavy_components | 0.010344 | 0.004776 | 2.2x faster |
| index_modification_mixed | 0.002748 | 0.001835 | 1.5x faster |
| index_lookup_exact_heavy_components | 0.002968 | 0.002203 | 1.3x faster |
| index_lookup_exact_plain | 0.001031 | 0.001043 | same |
| index_lookup_nonempty_first | 0.000242 | 0.000242 | same |
| index_lookup_nonempty_all | 0.024955 | 0.024100 | same |
| index_lookup_item_single_item | 0.717375 | 0.785046 | 1.09x slower |
| index_modification_plain | 0.000451 | 0.000569 | 1.26x slower |
| index_lookup_exact_mixed | 0.001296 | 0.001623 | 1.25x slower |

### How this differs from the 26.1 result, and what I cannot explain

On 26.1 the modification benchmarks regressed, roughly 2x on the spread shape and 4.9x with a heavy component payload. **On 1.21 they improve instead**, 5.9x and 2.2x. The reason is that the 1.21 baseline is far worse to begin with: `index_modification` starts at 0.009933 here against 0.000744 on 26.1, and `index_lookup_item` at 9.51 against 0.27. The added hashing cost is real on both branches, but on 1.21 it is swamped by how much worse the collisions were.

I have not isolated why the 1.21 baseline collides so much harder. The most likely explanation is that 1.21.1 registers fewer items, so spreading 5000 instances over them puts more component variants on each item and lengthens every collision chain. That is a hypothesis I did not test, not a measured finding.

Three rows still regress, all small and all with overlapping distributions at n=3:

* `index_modification_plain` 1.26x (before 0.000438 to 0.000544, after 0.000463 to 0.000963)
* `index_lookup_exact_mixed` 1.25x
* `index_lookup_item_single_item` 1.09x, which is consistent across runs. That query returns every variant of an item that has 5000 of them, so classification cannot narrow it and each result costs a dearer hash.

## Tests

* `TestItemStackHelpersHashCode`: equal stacks hash equal, different items and counts hash differently, components affect the hash, 1000 component variants of one item produce over 99% distinct hashes, plain stacks still spread over items and counts, a component set back to its default hashes as plain again, and the hash agrees with `ItemStack.isSameItemSameComponents` plus count over 100 samples.
* `TestSingleClassifiedAbsentClassifier`: the five affected methods return empty for an absent classifier and correct results for a present one, and a counting inner collection asserts that nothing is scanned in the absent case, so the optimization is pinned and not just its answer.

Both are written against this branch's JUnit 4 setup and bootstrap items through intrusive holders, matching the existing item tests here. A separate commit makes that adjustment, so the port is visible on its own.

`./gradlew build` passes on all loaders.

## Relationship to the 26.1 branch

CyclopsMC/CyclopsCore#238 is the same change against `master-26-lts` and stays open. The five ingredient collection files are byte identical between the two branches, so only `ItemStackHelpersCommon` and the tests needed adjusting. Merge whichever suits your upmerge direction; they are not meant to both land independently.

## Notes for review

* This changes the behaviour of every IntegratedDynamics storage lookup. It needs a CyclopsCore version bump, and dependent mods will need to require it.
* Changes 2 and 3 stand on their own and could be split out. Change 2 in particular is a fix for a pre-existing bug and helps regardless of the hash.
* No changelog entry, as requested.

## What was not verified

* No profiling was done on 1.21; the profiles that motivated changes 2 and 3 were taken on 26.1.
* No terminal open measurements were taken on 1.21. Those exist only for 26.1.
* Fabric and Forge keep the common `hasComponentPatch` implementation, which builds a patch instance for stacks that carry one. Only NeoForge was benchmarked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mxjin31W1Lmq5XK1CCe84v)_