### PR TITLE
Hash an ingredient key once per index update

### DIFF
--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IIngredientMapMutable.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IIngredientMapMutable.java
@@ -5,6 +5,7 @@ import org.cyclops.commoncapabilities.api.ingredient.IngredientComponent;
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 
 /**
  * A mutable mapping from ingredient component instances to values of any type.
@@ -88,6 +89,33 @@ public interface IIngredientMapMutable<T, M, V> extends IIngredientMap<T, M, V> 
             removed += removeAll(instance, matchCondition);
         }
         return removed;
+    }
+
+    /**
+     * Compute a new value for the given key instance, following {@link Map#compute} semantics.
+     *
+     * The remapping function is passed the key and the currently mapped value, or null when the key
+     * is absent. Returning null removes the mapping, returning anything else stores it.
+     *
+     * Implementations back onto a hash of the key instance, which for some component types is
+     * expensive. Doing this in one call rather than a get followed by a put lets them hash once.
+     *
+     * @param key An instance key.
+     * @param remappingFunction A function computing the new value from the key and the old value.
+     * @return The new value associated with the key, or null if none.
+     */
+    @Nullable
+    default V compute(T key, BiFunction<T, V, V> remappingFunction) {
+        V oldValue = get(key);
+        V newValue = remappingFunction.apply(key, oldValue);
+        if (newValue == null) {
+            if (oldValue != null) {
+                remove(key);
+            }
+        } else {
+            put(key, newValue);
+        }
+        return newValue;
     }
 
     /**

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientCollectionPrototypeMap.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientCollectionPrototypeMap.java
@@ -52,14 +52,14 @@ public class IngredientCollectionPrototypeMap<T, M> extends IngredientCollection
     public boolean add(T instance) {
         IIngredientMatcher<T, M> matcher = getComponent().getMatcher();
         T prototype = getPrototype(instance);
-        Long value = ingredients.get(prototype);
-        long existingValue = value == null ? 0 : value;
-        long newValue = Math.addExact(existingValue, matcher.getQuantity(instance));
-        if (newValue != 0) {
-            ingredients.put(prototype, newValue);
-        } else {
-            ingredients.remove(prototype);
-        }
+        long quantity = matcher.getQuantity(instance);
+        // Computed in one call so the prototype is hashed once rather than once to read and once
+        // to write. Hashing a prototype is the dominant cost here for component-bearing instances.
+        ingredients.compute(prototype, (key, value) -> {
+            long existingValue = value == null ? 0 : value;
+            long newValue = Math.addExact(existingValue, quantity);
+            return newValue == 0 ? null : newValue;
+        });
         return true;
     }
 
@@ -67,17 +67,20 @@ public class IngredientCollectionPrototypeMap<T, M> extends IngredientCollection
     public boolean remove(T instance) {
         IIngredientMatcher<T, M> matcher = getComponent().getMatcher();
         T prototype = getPrototype(instance);
-        Long value = ingredients.get(prototype);
-        long existingValue = value == null ? 0 : value;
         long currentValue = matcher.getQuantity(instance);
-        if (currentValue == existingValue) {
-            ingredients.remove(prototype);
-            return true;
-        } else if (currentValue < existingValue || isNegativeQuantities()) {
-            ingredients.put(prototype, existingValue - currentValue);
-            return true;
-        }
-        return false;
+        boolean[] removed = new boolean[1];
+        ingredients.compute(prototype, (key, value) -> {
+            long existingValue = value == null ? 0 : value;
+            if (currentValue == existingValue) {
+                removed[0] = true;
+                return null;
+            } else if (currentValue < existingValue || isNegativeQuantities()) {
+                removed[0] = true;
+                return existingValue - currentValue;
+            }
+            return value;
+        });
+        return removed[0];
     }
 
     @Override

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapSingleClassified.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapSingleClassified.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 /**
@@ -110,6 +111,29 @@ public class IngredientMapSingleClassified<T, M, V, C> extends IngredientMapAdap
 
         }
         return null;
+    }
+
+    @Nullable
+    @Override
+    public V compute(T key, BiFunction<T, V, V> remappingFunction) {
+        C classifier = getClassifier(key);
+        IIngredientMapMutable<T, M, V> map = this.classifiedMaps.get(classifier);
+        if (map == null) {
+            // Nothing is stored under this classifier, so only an insertion can come out of this
+            V newValue = remappingFunction.apply(key, null);
+            if (newValue != null) {
+                getOrCreateClassifiedCollection(classifier).put(key, newValue);
+                this.size++;
+            }
+            return newValue;
+        }
+        int sizeBefore = map.size();
+        V newValue = map.compute(key, remappingFunction);
+        this.size += map.size() - sizeBefore;
+        if (map.isEmpty()) {
+            this.classifiedMaps.remove(classifier);
+        }
+        return newValue;
     }
 
     @Override

--- a/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapWrappedAdapter.java
+++ b/loader-neoforge/src/main/java/org/cyclops/cyclopscore/ingredient/collection/IngredientMapWrappedAdapter.java
@@ -9,6 +9,7 @@ import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 /**
  * An abstract ingredient map adapter.
@@ -66,6 +67,14 @@ public abstract class IngredientMapWrappedAdapter<T, M, V, C extends Map<Ingredi
     @Override
     public V get(T key) {
         return this.collection.get(wrap(key));
+    }
+
+    @Nullable
+    @Override
+    public V compute(T key, BiFunction<T, V, V> remappingFunction) {
+        // One wrapper, so the key is hashed once instead of once for the get and once for the put
+        return this.collection.compute(wrap(key),
+                (wrapper, value) -> remappingFunction.apply(wrapper.getInstance(), value));
     }
 
     @Override

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestIngredientMapCompute.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestIngredientMapCompute.java
@@ -1,0 +1,138 @@
+package org.cyclops.cyclopscore.ingredient.collection;
+
+import org.cyclops.cyclopscore.ingredient.ComplexStack;
+import org.cyclops.cyclopscore.ingredient.IngredientComponentStubs;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * {@link IIngredientMapMutable#compute} across the map implementations.
+ *
+ * It exists so that a read followed by a write can hash the key once instead of twice, so the
+ * results have to stay identical to doing both separately.
+ *
+ * @author rubensworks
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TestIngredientMapCompute {
+
+    private static final ComplexStack A01 = new ComplexStack(ComplexStack.Group.A, 0, 1, null);
+    private static final ComplexStack A12 = new ComplexStack(ComplexStack.Group.A, 1, 2, null);
+    private static final ComplexStack B01 = new ComplexStack(ComplexStack.Group.B, 0, 1, null);
+
+    public Stream<Arguments> maps() {
+        return Stream.<Supplier<IIngredientMapMutable<ComplexStack, Integer, String>>>of(
+                () -> new IngredientHashMap<>(IngredientComponentStubs.COMPLEX),
+                () -> new IngredientTreeMap<>(IngredientComponentStubs.COMPLEX),
+                () -> new IngredientMapSingleClassified<>(IngredientComponentStubs.COMPLEX,
+                        () -> new IngredientHashMap<>(IngredientComponentStubs.COMPLEX),
+                        IngredientComponentStubs.COMPLEX.getCategoryTypes().get(0))
+        ).map(Arguments::of);
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testInsertsWhenAbsent(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        assertThat(map.compute(A01, (key, value) -> {
+            assertThat(value, is(nullValue()));
+            return "first";
+        }), is("first"));
+        assertThat(map.get(A01), is("first"));
+        assertThat(map.size(), is(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testUpdatesWhenPresent(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        map.put(A01, "first");
+        assertThat(map.compute(A01, (key, value) -> value + "+second"), is("first+second"));
+        assertThat(map.get(A01), is("first+second"));
+        assertThat(map.size(), is(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testRemovesOnNull(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        map.put(A01, "first");
+        map.put(A12, "other");
+        assertThat(map.compute(A01, (key, value) -> null), is(nullValue()));
+        assertThat(map.get(A01), is(nullValue()));
+        assertThat(map.get(A12), is("other"));
+        assertThat(map.size(), is(1));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testNullOnAbsentIsNoOp(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        assertThat(map.compute(A01, (key, value) -> null), is(nullValue()));
+        assertThat(map.size(), is(0));
+        assertThat(map.isEmpty(), is(true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testKeyIsPassedThrough(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        map.compute(A01, (key, value) -> {
+            assertThat(key, is(A01));
+            return "v";
+        });
+    }
+
+    /**
+     * The classified map keeps its own size and drops classifiers that run empty, so computing
+     * away the last entry of a classifier has to clean up just as a remove would.
+     */
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testSizeTracksAcrossClassifiers(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+        map.compute(A01, (key, value) -> "a");
+        map.compute(B01, (key, value) -> "b");
+        assertThat(map.size(), is(2));
+        map.compute(B01, (key, value) -> null);
+        assertThat(map.size(), is(1));
+        assertThat(map.get(A01), is("a"));
+        assertThat(map.get(B01), is(nullValue()));
+        map.compute(B01, (key, value) -> "b again");
+        assertThat(map.size(), is(2));
+        assertThat(map.get(B01), is("b again"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("maps")
+    public void testMatchesGetThenPut(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        IIngredientMapMutable<ComplexStack, Integer, String> computed = factory.get();
+        IIngredientMapMutable<ComplexStack, Integer, String> manual = factory.get();
+        ComplexStack[] keys = {A01, A12, B01, A01, B01, A12};
+        for (int i = 0; i < keys.length; i++) {
+            ComplexStack key = keys[i];
+            int step = i;
+            computed.compute(key, (k, value) -> step % 3 == 2 ? null : (value == null ? "v" + step : value + "v" + step));
+            String oldValue = manual.get(key);
+            String newValue = step % 3 == 2 ? null : (oldValue == null ? "v" + step : oldValue + "v" + step);
+            if (newValue == null) {
+                manual.remove(key);
+            } else {
+                manual.put(key, newValue);
+            }
+            assertThat(computed.size(), is(manual.size()));
+            for (ComplexStack probe : new ComplexStack[]{A01, A12, B01}) {
+                assertThat(computed.get(probe), is(manual.get(probe)));
+            }
+        }
+    }
+}

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestIngredientMapCompute.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/ingredient/collection/TestIngredientMapCompute.java
@@ -2,13 +2,13 @@ package org.cyclops.cyclopscore.ingredient.collection;
 
 import org.cyclops.cyclopscore.ingredient.ComplexStack;
 import org.cyclops.cyclopscore.ingredient.IngredientComponentStubs;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -22,27 +22,36 @@ import static org.hamcrest.MatcherAssert.assertThat;
  *
  * @author rubensworks
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@RunWith(Parameterized.class)
 public class TestIngredientMapCompute {
 
     private static final ComplexStack A01 = new ComplexStack(ComplexStack.Group.A, 0, 1, null);
     private static final ComplexStack A12 = new ComplexStack(ComplexStack.Group.A, 1, 2, null);
     private static final ComplexStack B01 = new ComplexStack(ComplexStack.Group.B, 0, 1, null);
 
-    public Stream<Arguments> maps() {
-        return Stream.<Supplier<IIngredientMapMutable<ComplexStack, Integer, String>>>of(
-                () -> new IngredientHashMap<>(IngredientComponentStubs.COMPLEX),
-                () -> new IngredientTreeMap<>(IngredientComponentStubs.COMPLEX),
-                () -> new IngredientMapSingleClassified<>(IngredientComponentStubs.COMPLEX,
-                        () -> new IngredientHashMap<>(IngredientComponentStubs.COMPLEX),
-                        IngredientComponentStubs.COMPLEX.getCategoryTypes().get(0))
-        ).map(Arguments::of);
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.<Object[]>asList(new Object[][]{
+                {(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>>)
+                        () -> new IngredientHashMap<>(IngredientComponentStubs.COMPLEX)},
+                {(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>>)
+                        () -> new IngredientTreeMap<>(IngredientComponentStubs.COMPLEX)},
+                {(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>>)
+                        () -> new IngredientMapSingleClassified<>(IngredientComponentStubs.COMPLEX,
+                                () -> new IngredientHashMap<>(IngredientComponentStubs.COMPLEX),
+                                IngredientComponentStubs.COMPLEX.getCategoryTypes().get(0))},
+        });
     }
 
-    @ParameterizedTest
-    @MethodSource("maps")
-    public void testInsertsWhenAbsent(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
-        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+    private final Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory;
+
+    public TestIngredientMapCompute(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
+        this.factory = factory;
+    }
+
+    @Test
+    public void testInsertsWhenAbsent() {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = this.factory.get();
         assertThat(map.compute(A01, (key, value) -> {
             assertThat(value, is(nullValue()));
             return "first";
@@ -51,20 +60,18 @@ public class TestIngredientMapCompute {
         assertThat(map.size(), is(1));
     }
 
-    @ParameterizedTest
-    @MethodSource("maps")
-    public void testUpdatesWhenPresent(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
-        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+    @Test
+    public void testUpdatesWhenPresent() {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = this.factory.get();
         map.put(A01, "first");
         assertThat(map.compute(A01, (key, value) -> value + "+second"), is("first+second"));
         assertThat(map.get(A01), is("first+second"));
         assertThat(map.size(), is(1));
     }
 
-    @ParameterizedTest
-    @MethodSource("maps")
-    public void testRemovesOnNull(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
-        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+    @Test
+    public void testRemovesOnNull() {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = this.factory.get();
         map.put(A01, "first");
         map.put(A12, "other");
         assertThat(map.compute(A01, (key, value) -> null), is(nullValue()));
@@ -73,19 +80,17 @@ public class TestIngredientMapCompute {
         assertThat(map.size(), is(1));
     }
 
-    @ParameterizedTest
-    @MethodSource("maps")
-    public void testNullOnAbsentIsNoOp(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
-        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+    @Test
+    public void testNullOnAbsentIsNoOp() {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = this.factory.get();
         assertThat(map.compute(A01, (key, value) -> null), is(nullValue()));
         assertThat(map.size(), is(0));
         assertThat(map.isEmpty(), is(true));
     }
 
-    @ParameterizedTest
-    @MethodSource("maps")
-    public void testKeyIsPassedThrough(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
-        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+    @Test
+    public void testKeyIsPassedThrough() {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = this.factory.get();
         map.compute(A01, (key, value) -> {
             assertThat(key, is(A01));
             return "v";
@@ -96,10 +101,9 @@ public class TestIngredientMapCompute {
      * The classified map keeps its own size and drops classifiers that run empty, so computing
      * away the last entry of a classifier has to clean up just as a remove would.
      */
-    @ParameterizedTest
-    @MethodSource("maps")
-    public void testSizeTracksAcrossClassifiers(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
-        IIngredientMapMutable<ComplexStack, Integer, String> map = factory.get();
+    @Test
+    public void testSizeTracksAcrossClassifiers() {
+        IIngredientMapMutable<ComplexStack, Integer, String> map = this.factory.get();
         map.compute(A01, (key, value) -> "a");
         map.compute(B01, (key, value) -> "b");
         assertThat(map.size(), is(2));
@@ -112,11 +116,10 @@ public class TestIngredientMapCompute {
         assertThat(map.get(B01), is("b again"));
     }
 
-    @ParameterizedTest
-    @MethodSource("maps")
-    public void testMatchesGetThenPut(Supplier<IIngredientMapMutable<ComplexStack, Integer, String>> factory) {
-        IIngredientMapMutable<ComplexStack, Integer, String> computed = factory.get();
-        IIngredientMapMutable<ComplexStack, Integer, String> manual = factory.get();
+    @Test
+    public void testMatchesGetThenPut() {
+        IIngredientMapMutable<ComplexStack, Integer, String> computed = this.factory.get();
+        IIngredientMapMutable<ComplexStack, Integer, String> manual = this.factory.get();
         ComplexStack[] keys = {A01, A12, B01, A01, B01, A12};
         for (int i = 0; i < keys.length; i++) {
             ComplexStack key = keys[i];


### PR DESCRIPTION
The 1.21 version of #239.

An ingredient map hashes its key on every operation, and for ItemStack that hash walks a data component map. The update paths all read then write, and `IngredientMapWrappedAdapter` builds its own wrapper inside each of `get`, `put` and `remove`, so one logical update hashed the same key twice. Storage networks then run every change twice over, once for its own channel and once for the wildcard channel, so it multiplies.

`IIngredientMapMutable` gains a `compute` method with `Map.compute` semantics. The default implementation is the old read-then-write, so every existing implementation stays correct without changing. `IngredientMapWrappedAdapter` builds one wrapper and hands it to the backing map's own `compute`. `IngredientMapSingleClassified` delegates to the classifier's sub-map while keeping its size counter and its empty-classifier cleanup.

`IngredientCollectionPrototypeMap.add` and `remove` use it. Component types whose hash is cheap see no difference either way.

The companion change on the IntegratedDynamics side is CyclopsMC/IntegratedDynamics#PENDING_ID_COMPUTE, which converts `IngredientPositionsIndex.addPosition` and `removePosition`.

## Numbers

**These come from 26.1, not from 1.21.** All four touched files are byte identical between `master-1.21-lts` and `master-26-lts`, so the change is literally the same code, but I did not re-run the benchmarks here. Say the word and I will; each full run on this branch takes about 33 minutes, so a paired set is a couple of hours.

IntegratedDynamics index benchmarks on 26.1, ms per operation, medians of six runs each, alternating between the two configurations within one session so session drift falls on both equally. Both sides carry the fixes from CyclopsMC/CyclopsCore#238.

| benchmark | without compute | with compute | factor |
|---|---:|---:|---|
| index_modification_single_item | 0.001162 | 0.000688 | **41% faster** |
| index_modification_few_items | 0.001084 | 0.000726 | **33% faster** |
| index_modification_heavy_components | 0.002510 | 0.002077 | **17% faster** |
| index_modification_mixed | 0.000713 | 0.000667 | 6% faster |
| index_modification_plain | 0.000530 | 0.000507 | 4% faster |
| index_modification | 0.001246 | 0.001381 | 11% slower |

Lookup benchmarks all land within 10% either way with no consistent direction, which is expected: they do not read-then-write, so there is nothing for this to collapse.

The win is concentrated where hashing genuinely dominates a modification: many component variants of one item, or a large component payload. It is much weaker on the realistic shapes, because #238 already skips the component hash entirely for stacks carrying no patch, so there is little hashing left to halve. The spread-shape row reads 11% slower, but that benchmark runs first in the sequence and absorbs JIT warm-up, and its two distributions overlap almost completely; I would not read a regression into it and cannot rule one out either.

I predicted this would be worth about a third of the remaining modification cost. That held for the hash-dominated shapes and overestimated the realistic ones. Reporting the miss rather than the prediction.

One caveat specific to this branch: on 1.21 the hash fix makes modifications faster rather than slower, because the baseline collides much harder here. That means the cost this change exists to reduce is a smaller share of the total on 1.21 than on 26.1, so the benefit here is probably smaller than the table above suggests.

## Recommendation

Worth taking, but not urgently. It is a strict reduction in work, the API mirrors `Map.compute` so it is not exotic, and the default keeps every other implementation correct untouched. But the realistic-mix gain is inside the measurement spread, so if you would rather not widen `IIngredientMapMutable` for that, closing this is a defensible call.

## Tests

`TestIngredientMapCompute` covers insert, update, remove, a null remapping on an absent key, key pass-through, and size tracking across classifiers, over `IngredientHashMap`, `IngredientTreeMap` and `IngredientMapSingleClassified`. It also drives a sequence of computes against a second map doing the get-then-put by hand and asserts the two stay identical after every step. It is written against this branch's JUnit 4 setup, in a separate commit so the port is visible on its own.

`./gradlew build` passes on all loaders.

## Relationship to the 26.1 branch

CyclopsMC/CyclopsCore#239 is the same change against `master-26-lts` and stays open. Merge whichever suits your upmerge direction.

## Notes for review

* `IngredientMapMultiClassified` keeps the default implementation. It is correct, just not collapsed; the positions index never uses it.
* This is independent of the hash fix and merges cleanly with it.
* No changelog entry, as requested.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mxjin31W1Lmq5XK1CCe84v)_