### PR TITLE
Identify inventories by instance instead of by contents

### DIFF
--- a/loader-common/src/main/java/org/cyclops/cyclopscore/inventory/SimpleInventoryCommon.java
+++ b/loader-common/src/main/java/org/cyclops/cyclopscore/inventory/SimpleInventoryCommon.java
@@ -24,6 +24,9 @@ import java.util.stream.IntStream;
 
 /**
  * A basic inventory implementation.
+ *
+ * Instances are compared by identity, not by contents.
+ *
  * @author rubensworks
  *
  */
@@ -285,25 +288,8 @@ public class SimpleInventoryCommon implements INBTInventory, WorldlyContainer {
         return true;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SimpleInventoryCommon)) return false;
-
-        SimpleInventoryCommon that = (SimpleInventoryCommon) o;
-
-        if (stackLimit != that.stackLimit) return false;
-        if (contents.length != that.contents.length) return false;
-        for (int i = 0; i < contents.length; i++) {
-            if (!ItemStack.isSameItemSameComponents(contents[i], that.contents[i])) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return this.hash;
-    }
+    // Deliberately no equals/hashCode overrides: inventories are mutable and are identified by instance.
+    // Comparing them by contents made two separate but equally-filled inventories interchangeable as map keys,
+    // which corrupts equality-keyed container caches such as Fabric's InventoryStorage.
+    // Use getState() if you need to detect content changes.
 }

--- a/loader-neoforge/src/test/java/org/cyclops/cyclopscore/inventory/TestSimpleInventoryCommon.java
+++ b/loader-neoforge/src/test/java/org/cyclops/cyclopscore/inventory/TestSimpleInventoryCommon.java
@@ -1,0 +1,87 @@
+package org.cyclops.cyclopscore.inventory;
+
+import com.google.common.collect.Maps;
+import net.minecraft.DetectedVersion;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit tests for {@link SimpleInventoryCommon}.
+ *
+ * Inventories are mutable and must be identified by instance.
+ * Item transfer APIs cache their wrappers in maps keyed on the container,
+ * so comparing inventories by contents makes two separate chests share one wrapper,
+ * and a hash code that changes on every modification makes such a map lose its entries.
+ *
+ * @author rubensworks
+ */
+public class TestSimpleInventoryCommon {
+
+    static {
+        SharedConstants.setVersion(DetectedVersion.BUILT_IN);
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    public void testEqualsIsIdentityBased() {
+        SimpleInventoryCommon inv1 = new SimpleInventoryCommon(5, 64);
+        SimpleInventoryCommon inv2 = new SimpleInventoryCommon(5, 64);
+
+        assertThat("Inventory does not equal itself", inv1.equals(inv1), is(true));
+        assertThat("Two empty inventories of equal size are equal", inv1.equals(inv2), is(false));
+
+        inv1.setItem(0, new ItemStack(Items.APPLE));
+        inv2.setItem(0, new ItemStack(Items.APPLE));
+        assertThat("Two inventories with equal contents are equal", inv1.equals(inv2), is(false));
+    }
+
+    @Test
+    public void testHashCodeIsStableAcrossModifications() {
+        SimpleInventoryCommon inv = new SimpleInventoryCommon(5, 64);
+
+        int hashCodeBefore = inv.hashCode();
+        inv.setItem(0, new ItemStack(Items.APPLE));
+        inv.setItem(1, new ItemStack(Items.DIRT));
+        inv.setItem(0, ItemStack.EMPTY);
+
+        assertThat("Hash code changed after modifying the inventory", inv.hashCode(), is(hashCodeBefore));
+    }
+
+    @Test
+    public void testStateStillChangesOnModification() {
+        SimpleInventoryCommon inv = new SimpleInventoryCommon(5, 64);
+
+        int stateBefore = inv.getState();
+        inv.setItem(0, new ItemStack(Items.APPLE));
+
+        assertThat("State did not change after modifying the inventory", inv.getState(), is(not(stateBefore)));
+    }
+
+    @Test
+    public void testDistinctInventoriesGetDistinctMapEntries() {
+        SimpleInventoryCommon inv1 = new SimpleInventoryCommon(5, 64);
+        SimpleInventoryCommon inv2 = new SimpleInventoryCommon(5, 64);
+
+        // This is how item transfer APIs such as Fabric's InventoryStorage cache their wrappers
+        Map<Container, Object> wrappers = Maps.newHashMap();
+        Object wrapper1 = wrappers.computeIfAbsent(inv1, i -> new Object());
+        Object wrapper2 = wrappers.computeIfAbsent(inv2, i -> new Object());
+        assertThat("Two inventories share a single cached wrapper", wrapper1, is(not(sameInstance(wrapper2))));
+
+        // Looking up an inventory again after it changed must still find its own wrapper
+        inv1.setItem(0, new ItemStack(Items.APPLE));
+        assertThat("Inventory lost its cached wrapper after being modified",
+                wrappers.computeIfAbsent(inv1, i -> new Object()), is(sameInstance(wrapper1)));
+    }
+}


### PR DESCRIPTION
Root fix for CyclopsMC/ColossalChests#208, where items dropped into a Colossal Chest on Fabric silently disappeared and the chest's item list read back another chest's contents.

## The problem

`SimpleInventoryCommon` overrode `equals` to compare contents, and `hashCode` to return the modification counter:

```java
public boolean equals(Object o) { /* same stack limit, same size, same item types per slot */ }
public int hashCode() { return this.hash; }  // incremented on every setChanged()
```

Both are wrong for a mutable container, and together they break any item transfer API that caches its wrappers in a map keyed on the container. Fabric's `InventoryStorage` is exactly that, with equals-based keys:

```java
// TODO: should have identity semantics?
private static final Map<Inventory, InventoryStorageImpl> WRAPPERS = new MapMaker().weakValues().makeMap();

public static InventoryStorage of(Inventory inventory, @Nullable Direction direction) {
    InventoryStorageImpl storage = WRAPPERS.computeIfAbsent(inventory, ...);
```

So two empty inventories of the same size were equal and hashed the same, and whichever was looked up second was handed the first one's storage. Everything inserted or read then went to the wrong block. Separately, the changing hash code meant an inventory could no longer find its own entry after any modification, so a fresh wrapper was built on each lookup — `InventorySlotWrapper` explicitly documents that only one instance may exist per slot or "the transaction logic will not work correctly".

## The fix

Instances are compared by identity. `getState()` still returns the modification counter, so change detection (the `InventoryState` capability, GUI syncing) is unaffected.

The deprecated NeoForge-only `SimpleInventory` deliberately keeps its contents-based equality: it backs the `cyclopscore:inventory` data component, and data components need value equality. Its `hashCode` is inconsistent with that `equals` for the same reason described above, but that is a separate concern on a class already marked for removal, so this PR leaves it alone.

## Compatibility

This is a behaviour change for anything that compared two `SimpleInventoryCommon` instances by value. Nothing in this repository did. A downstream mod that relied on it would need its own subclass — note that value equality was already unreliable here, since the inconsistent `hashCode` made these inventories unusable in any hash-based collection.

## Tests

`TestSimpleInventoryCommon` covers the invariants the transfer APIs depend on: identity equality, a hash code stable across modifications, `getState()` still changing on modification, and a container-keyed map giving two inventories two entries and not losing an entry when an inventory changes. Three of the four fail on the current code.

Verified end to end against ColossalChests: with this change applied to the CyclopsCore version ColossalChests pins, and CyclopsMC/ColossalChests#209's local workaround removed, all 95 of its game tests pass — including the new item-storage regression test and the three Fabric hopper tests that had been disabled for an "unknown reason". Those game tests are worth keeping regardless, since they cover the behaviour end to end.

`:loader-neoforge:test` (4 tests, 0 failures), `:loader-common:build`, `:loader-fabric:build` and `:loader-fabric:runGameTestServer` all pass locally. The Forge loader was not built locally; CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wbskd84GPZPE1rB7spHkdn